### PR TITLE
PR-Sprint-1/issue#8---create-text-component

### DIFF
--- a/client/components/CustomButton.js
+++ b/client/components/CustomButton.js
@@ -1,9 +1,10 @@
-import { Text, TouchableOpacity } from 'react-native'
+import { TouchableOpacity } from 'react-native'
 import React from 'react'
 import { customButton } from '../styles/components/custom-button'
+import CustomTitle from './CustomTitle';
 
-const Button = ({onPress, title, background, type}) => {
-  const backgroundStyle = background === 'green' 
+const CustomButton = ({onPress, title, background, type}) => {
+  const backgroundStyle = background === 'green'
     ? customButton.green
     : customButton.white;
   
@@ -11,14 +12,21 @@ const Button = ({onPress, title, background, type}) => {
     ? customButton.modal
     : null;
 
+  const typeTitle = background === 'white'
+    ? 'ButtonSmallGreen'
+    : type === 'modal' && background === 'green'
+    ? 'ButtonSmall'
+    : 'ButtonBig'
+
   return (
       <TouchableOpacity 
         onPress={onPress}
         style={[customButton.container, backgroundStyle, typeStyle]}
       >
-        <Text>{title}</Text>
+        <CustomTitle title={title} type={typeTitle}
+        />
       </TouchableOpacity>
   )
 }
 
-export default Button
+export default CustomButton

--- a/client/components/CustomButton.js
+++ b/client/components/CustomButton.js
@@ -1,0 +1,24 @@
+import { Text, TouchableOpacity } from 'react-native'
+import React from 'react'
+import { customButton } from '../styles/components/custom-button'
+
+const Button = ({onPress, title, background, type}) => {
+  const backgroundStyle = background === 'green' 
+    ? customButton.green
+    : customButton.white;
+  
+  const typeStyle = type === 'modal'
+    ? customButton.modal
+    : null;
+
+  return (
+      <TouchableOpacity 
+        onPress={onPress}
+        style={[customButton.container, backgroundStyle, typeStyle]}
+      >
+        <Text>{title}</Text>
+      </TouchableOpacity>
+  )
+}
+
+export default Button

--- a/client/components/CustomText.js
+++ b/client/components/CustomText.js
@@ -1,0 +1,20 @@
+import { View, Text } from "react-native";
+import React from "react";
+import { fontsTheme } from "../styles/fontsTheme";
+
+const CustomText = ({ text, type, numberOfLines = 1 }) => {
+  const textStyle = type ? type : "TextBig";
+  return (
+    <View>
+      <Text
+        style={[fontsTheme[textStyle]]}
+        numberOfLines={numberOfLines}
+        ellipsizeMode="tail"
+      >
+        {text}
+      </Text>
+    </View>
+  );
+};
+
+export default CustomText;

--- a/client/components/CustomTitle.js
+++ b/client/components/CustomTitle.js
@@ -1,0 +1,17 @@
+import { View, Text } from 'react-native'
+import React from 'react'
+import { fontsTheme } from '../styles/fontsTheme'
+
+const CustomTitle = ({title, type, numberOfLines = 1}) => {
+    
+    return (
+          <View>
+              <Text 
+              style={[fontsTheme[type]]}
+              numberOfLines={numberOfLines} 
+              ellipsizeMode="tail">{title}</Text>
+          </View>
+    )
+  }
+
+export default CustomTitle

--- a/client/styles/colorsTheme.js
+++ b/client/styles/colorsTheme.js
@@ -1,10 +1,10 @@
 export const colorsTheme = {
   red: "#EB5757",
-  yellow: "F1C40F",
-  lightGreen: "53BB53",
-  teal: "067580",
-  darkGreen: "466146",
-  black: "2F3743",
-  white: "FDFDFD",
-  lightGray: "ECF1F6",
+  yellow: "#F1C40F",
+  lightGreen: "#53BB53",
+  teal: "#067580",
+  darkGreen: "#466146",
+  black: "#2F3743",
+  white: "#FDFDFD",
+  lightGray: "#ECF1F6",
 };

--- a/client/styles/components/custom-button.js
+++ b/client/styles/components/custom-button.js
@@ -1,0 +1,29 @@
+import { StyleSheet } from "react-native";
+import { colorsTheme } from "../colorsTheme";
+
+export const customButton = StyleSheet.create({
+
+  container: {
+    width: '90%',
+    height: 54,
+    alignItems: "center",
+    justifyContent: "center",
+    margin: 10,
+    borderRadius: 15,
+  },
+ 
+  modal: {
+    width: '40%',
+  },
+
+  green: {
+    backgroundColor: colorsTheme.darkGreen,
+  },
+
+  white: {
+    backgroundColor: colorsTheme.white,
+    borderWidth: 1,
+    borderColor: colorsTheme.darkGreen,
+  },
+
+});

--- a/client/styles/fontsTheme.js
+++ b/client/styles/fontsTheme.js
@@ -25,10 +25,12 @@ export const fontsTheme = {
   ButtonBig: {
     ...Inter_500Medium,
     fontSize: 16,
+    color: colorsTheme.white
   },
   ButtonSmall: {
     ...Inter_500Medium,
     fontSize: 14,
+    color: colorsTheme.white
   },
   TextBig: {
     ...Inter_400Regular,

--- a/client/styles/fontsTheme.js
+++ b/client/styles/fontsTheme.js
@@ -32,6 +32,11 @@ export const fontsTheme = {
     fontSize: 14,
     color: colorsTheme.white
   },
+  ButtonSmallGreen: {
+    ...Inter_500Medium,
+    fontSize: 14,
+    color: colorsTheme.darkGreen
+  },
   TextBig: {
     ...Inter_400Regular,
     fontSize: 14,


### PR DESCRIPTION
## Create Reusable CustomText Component

### Description
Develop a reusable CustomText component to standardize text styling across the application. The component supports two size options: TextSmall and TextBig, with TextBig set as the default when no type is specified.

### Acceptance Criteria
- The CustomText component renders correctly with all customizable props.
- Supports TextSmall and TextBig styles.
- Defaults to TextBig if no type is provided.

### Usage:

```
<CustomText text={"Testing new text component"} type={"TextSmall"} />
```

### Preview:
![Screen Shot 2025-03-13 at 10 59 58](https://github.com/user-attachments/assets/c390c7a9-309f-4474-91e1-a5de7c6328ac)
![Screen Shot 2025-03-13 at 11 00 29](https://github.com/user-attachments/assets/cbe671ce-49ce-43fd-9aae-5a2e76ba5de1)



