### PR TITLE
PR-Sprint-1/issue#11---create a balance display component

### DIFF
--- a/client/components/AddButton.js
+++ b/client/components/AddButton.js
@@ -1,0 +1,21 @@
+import { TouchableOpacity, View } from 'react-native'
+import React from 'react'
+import { Ionicons } from "@expo/vector-icons";
+import { colorsTheme } from '../styles/colorsTheme';
+import { addButton } from '../styles/components/add-button';
+
+const AddButton = ({onPress, isActiveAddButton}) => {
+    
+  return (
+    <TouchableOpacity 
+        onPress={onPress}
+        style={addButton.position}
+    >
+    <View style={addButton.background}>
+    </View>
+      <Ionicons name={isActiveAddButton ? 'close-circle': 'add-circle'} size={80} color={colorsTheme.yellow} />
+    </TouchableOpacity>
+  )
+}
+
+export default AddButton

--- a/client/components/BalanceDisplay.js
+++ b/client/components/BalanceDisplay.js
@@ -1,0 +1,37 @@
+import { View } from 'react-native'
+import React from 'react'
+import { Ionicons } from "@expo/vector-icons";
+import { LinearGradient } from 'expo-linear-gradient';
+import CustomTitle from './CustomTitle'
+import { balanceDisplay } from '../styles/components/balance-display'
+import { colorsTheme } from '../styles/colorsTheme';
+
+const BalanceDisplay = ({income = 0, expense = 0}) => {
+    const validIncome = Number(income) || 0;
+    const validExpense = Number(expense) || 0;
+    const balance = validIncome - validExpense || '0.00';
+  return (
+    < LinearGradient
+        start={[0, 1]}
+        end={[1, 0]}
+        colors={['#466146', '#30462E', '#2c3d2b']}
+        style={balanceDisplay.container}>
+        <View style={balanceDisplay.details}>
+            <CustomTitle title={'Balance'} type='TitleSmallWhite'/>
+            <View style={balanceDisplay.amount}>
+                <Ionicons testID="arrow-up" name={'arrow-up'} size={22} color={colorsTheme.white} />
+                <CustomTitle title={`$ ${validIncome.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`} type='TitleSmallWhite'/>
+            </View>
+        </View>
+        <View style={balanceDisplay.details}>
+            <CustomTitle title={`$ ${balance.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`} type='TitleMediumWhite'/>
+            <View style={balanceDisplay.amount}>
+                <Ionicons testID="arrow-down" name={'arrow-down'} size={22} color={colorsTheme.white} />
+                <CustomTitle title={`$ ${validExpense.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}`} type='TitleSmallWhite'/>
+            </View>
+        </View>
+    </LinearGradient>
+  )
+}
+
+export default BalanceDisplay

--- a/client/components/CustomButton.js
+++ b/client/components/CustomButton.js
@@ -1,9 +1,10 @@
-import { Text, TouchableOpacity } from 'react-native'
+import { TouchableOpacity } from 'react-native'
 import React from 'react'
 import { customButton } from '../styles/components/custom-button'
+import CustomTitle from './CustomTitle';
 
-const Button = ({onPress, title, background, type}) => {
-  const backgroundStyle = background === 'green' 
+const CustomButton = ({onPress, title, background, type}) => {
+  const backgroundStyle = background === 'green'
     ? customButton.green
     : customButton.white;
   
@@ -11,14 +12,21 @@ const Button = ({onPress, title, background, type}) => {
     ? customButton.modal
     : null;
 
+  const typeTitle = background === 'white'
+    ? 'ButtonSmallGreen'
+    : type === 'modal' && background === 'green'
+    ? 'ButtonSmall'
+    : 'ButtonBig'
+
   return (
       <TouchableOpacity 
         onPress={onPress}
         style={[customButton.container, backgroundStyle, typeStyle]}
       >
-        <Text>{title}</Text>
+        <CustomTitle title={title} type={typeTitle}
+        />
       </TouchableOpacity>
   )
 }
 
-export default Button
+export default CustomButton

--- a/client/components/CustomButton.js
+++ b/client/components/CustomButton.js
@@ -1,0 +1,24 @@
+import { Text, TouchableOpacity } from 'react-native'
+import React from 'react'
+import { customButton } from '../styles/components/custom-button'
+
+const Button = ({onPress, title, background, type}) => {
+  const backgroundStyle = background === 'green' 
+    ? customButton.green
+    : customButton.white;
+  
+  const typeStyle = type === 'modal'
+    ? customButton.modal
+    : null;
+
+  return (
+      <TouchableOpacity 
+        onPress={onPress}
+        style={[customButton.container, backgroundStyle, typeStyle]}
+      >
+        <Text>{title}</Text>
+      </TouchableOpacity>
+  )
+}
+
+export default Button

--- a/client/components/CustomTitle.js
+++ b/client/components/CustomTitle.js
@@ -1,0 +1,17 @@
+import { View, Text } from 'react-native'
+import React from 'react'
+import { fontsTheme } from '../styles/fontsTheme'
+
+const CustomTitle = ({title, type, numberOfLines = 1}) => {
+    
+    return (
+          <View>
+              <Text 
+              style={[fontsTheme[type]]}
+              numberOfLines={numberOfLines} 
+              ellipsizeMode="tail">{title}</Text>
+          </View>
+    )
+  }
+
+export default CustomTitle

--- a/client/components/__test__/BalanceDisplay.test.js
+++ b/client/components/__test__/BalanceDisplay.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render, within } from '@testing-library/react-native';
+import BalanceDisplay from '../BalanceDisplay';
+
+describe('BalanceDisplay Component', () => {
+  test('renders formatted income, expense, and balance correctly', () => {
+    const { getByText } = render(<BalanceDisplay income={12000} expense={1700} />);
+
+    // Verifica que los valores formateados estén en la pantalla
+    expect(getByText('Balance')).toBeTruthy(); // Título
+    expect(getByText('$ 12,000.00')).toBeTruthy(); // Income
+    expect(getByText('$ 1,700.00')).toBeTruthy(); // Expense
+    expect(getByText('$ 10,300.00')).toBeTruthy(); // Balance (income - expense)
+  });
+
+  test('renders balance as $0.00 when income and expense are 0', () => {
+    const { getAllByText } = render(<BalanceDisplay income={0} expense={0} />);
+
+    expect(getAllByText('$ 0.00')).toHaveLength(3); // Asegura que aparece 3 veces
+
+  });
+
+  test('renders balance as $0.00 when income and expense are null', () => {
+    const { getAllByText } = render(<BalanceDisplay income={null} expense={null} />);
+
+    expect(getAllByText('$ 0.00')).toHaveLength(3);
+  });
+
+  test('renders Ionicons correctly', () => {
+    const { getAllByTestId } = render(<BalanceDisplay income={12000} expense={1700} />);
+
+    // Verifica que hay dos iconos (arrow-up y arrow-down)
+    expect(getAllByTestId('arrow-up').length).toBe(1);
+    expect(getAllByTestId('arrow-down').length).toBe(1);
+  });
+});

--- a/client/jest.setup.js
+++ b/client/jest.setup.js
@@ -1,0 +1,20 @@
+jest.mock('expo-font');
+
+jest.mock('@expo/vector-icons', () => {
+    return {
+      Ionicons: ({ name, ...props }) => {
+        const React = require('react');
+        const { Text } = require('react-native');
+        return <Text {...props}>{name}</Text>;
+      },
+    };
+  });
+
+  jest.mock('./components/CustomTitle.js', () => {
+    const React = require('react');
+    const { Text } = require('react-native');
+    return {
+      __esModule: true,
+      default: ({ title }) => <Text>{title}</Text>,
+    };
+  });

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -17,6 +17,7 @@
         "expo-constants": "~17.0.7",
         "expo-font": "~13.0.4",
         "expo-haptics": "~14.0.1",
+        "expo-linear-gradient": "~14.0.2",
         "expo-linking": "~7.0.5",
         "expo-router": "~4.0.17",
         "expo-splash-screen": "~0.29.22",
@@ -36,6 +37,7 @@
       },
       "devDependencies": {
         "@babel/core": "^7.25.2",
+        "@testing-library/react-native": "^13.2.0",
         "@types/jest": "^29.5.12",
         "@types/react": "~18.3.12",
         "@types/react-test-renderer": "^18.3.0",
@@ -3914,6 +3916,32 @@
         "@sinonjs/commons": "^3.0.0"
       }
     },
+    "node_modules/@testing-library/react-native": {
+      "version": "13.2.0",
+      "resolved": "https://registry.npmjs.org/@testing-library/react-native/-/react-native-13.2.0.tgz",
+      "integrity": "sha512-3FX+vW/JScXkoH8VSCRTYF4KCHC56y4AI6TMDISfLna6r+z8kaSEmxH1I6NVaFOxoWX9yaHDyI26xh7BykmqKw==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.2",
+        "jest-matcher-utils": "^29.7.0",
+        "pretty-format": "^29.7.0",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "jest": ">=29.0.0",
+        "react": ">=18.2.0",
+        "react-native": ">=0.71",
+        "react-test-renderer": ">=18.2.0"
+      },
+      "peerDependenciesMeta": {
+        "jest": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@tootallnate/once": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
@@ -6494,6 +6522,16 @@
       "peerDependencies": {
         "expo": "*",
         "react": "*"
+      }
+    },
+    "node_modules/expo-linear-gradient": {
+      "version": "14.0.2",
+      "resolved": "https://registry.npmjs.org/expo-linear-gradient/-/expo-linear-gradient-14.0.2.tgz",
+      "integrity": "sha512-nvac1sPUfFFJ4mY25UkvubpUV/olrBH+uQw5k+beqSvQaVQiUfFtYzfRr+6HhYBNb4AEsOtpsCRkpDww3M2iGQ==",
+      "peerDependencies": {
+        "expo": "*",
+        "react": "*",
+        "react-native": "*"
       }
     },
     "node_modules/expo-linking": {
@@ -9943,6 +9981,15 @@
         "node": ">=4"
       }
     },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -11443,6 +11490,19 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/regenerate": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.2.tgz",
@@ -12442,6 +12502,18 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {

--- a/client/package.json
+++ b/client/package.json
@@ -11,8 +11,10 @@
     "test": "jest --watchAll",
     "lint": "expo lint"
   },
-  "jest": {
-    "preset": "jest-expo"
+    "jest": {
+    "preset": "jest-expo",
+    "setupFiles": ["<rootDir>/jest.setup.js"],
+    "clearMocks": true
   },
   "dependencies": {
     "@expo-google-fonts/inter": "^0.2.3",
@@ -24,6 +26,7 @@
     "expo-constants": "~17.0.7",
     "expo-font": "~13.0.4",
     "expo-haptics": "~14.0.1",
+    "expo-linear-gradient": "~14.0.2",
     "expo-linking": "~7.0.5",
     "expo-router": "~4.0.17",
     "expo-splash-screen": "~0.29.22",
@@ -43,6 +46,7 @@
   },
   "devDependencies": {
     "@babel/core": "^7.25.2",
+    "@testing-library/react-native": "^13.2.0",
     "@types/jest": "^29.5.12",
     "@types/react": "~18.3.12",
     "@types/react-test-renderer": "^18.3.0",

--- a/client/styles/colorsTheme.js
+++ b/client/styles/colorsTheme.js
@@ -1,10 +1,10 @@
 export const colorsTheme = {
   red: "#EB5757",
-  yellow: "F1C40F",
-  lightGreen: "53BB53",
-  teal: "067580",
-  darkGreen: "466146",
-  black: "2F3743",
-  white: "FDFDFD",
-  lightGray: "ECF1F6",
+  yellow: "#F1C40F",
+  lightGreen: "#53BB53",
+  teal: "#067580",
+  darkGreen: "#466146",
+  black: "#2F3743",
+  white: "#FDFDFD",
+  lightGray: "#ECF1F6",
 };

--- a/client/styles/components/add-button.js
+++ b/client/styles/components/add-button.js
@@ -1,0 +1,19 @@
+import { StyleSheet } from "react-native";
+import { colorsTheme } from "../colorsTheme";
+
+export const addButton = StyleSheet.create({
+    position: {
+        position: 'absolute',
+        alignItems: 'center',
+        justifyContent: 'center',
+        right: 30,
+        bottom: 30,
+    },
+    background: {
+        position: 'absolute',
+        width: 50,
+        height: 50,
+        borderRadius: 50,
+        backgroundColor: colorsTheme.white,
+    }
+})

--- a/client/styles/components/balance-display.js
+++ b/client/styles/components/balance-display.js
@@ -1,0 +1,19 @@
+import { StyleSheet } from "react-native";
+
+export const balanceDisplay = StyleSheet.create({
+    container: {
+        borderRadius: 20,
+        padding: 15,
+    },
+    details: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        marginVertical: 3,
+    },
+    amount: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        width: 120,
+        alignItems: 'center',
+    },
+})

--- a/client/styles/components/custom-button.js
+++ b/client/styles/components/custom-button.js
@@ -1,0 +1,29 @@
+import { StyleSheet } from "react-native";
+import { colorsTheme } from "../colorsTheme";
+
+export const customButton = StyleSheet.create({
+
+  container: {
+    width: '90%',
+    height: 54,
+    alignItems: "center",
+    justifyContent: "center",
+    margin: 10,
+    borderRadius: 15,
+  },
+ 
+  modal: {
+    width: '40%',
+  },
+
+  green: {
+    backgroundColor: colorsTheme.darkGreen,
+  },
+
+  white: {
+    backgroundColor: colorsTheme.white,
+    borderWidth: 1,
+    borderColor: colorsTheme.darkGreen,
+  },
+
+});

--- a/client/styles/fontsTheme.js
+++ b/client/styles/fontsTheme.js
@@ -25,10 +25,12 @@ export const fontsTheme = {
   ButtonBig: {
     ...Inter_500Medium,
     fontSize: 16,
+    color: colorsTheme.white
   },
   ButtonSmall: {
     ...Inter_500Medium,
     fontSize: 14,
+    color: colorsTheme.white
   },
   TextBig: {
     ...Inter_400Regular,

--- a/client/styles/fontsTheme.js
+++ b/client/styles/fontsTheme.js
@@ -18,9 +18,19 @@ export const fontsTheme = {
     ...Inter_700Bold,
     fontSize: 18,
   },
+  TitleMediumWhite: {
+    ...Inter_700Bold,
+    fontSize: 18,
+    color: colorsTheme.white
+  },
   TitleSmall: {
     ...Inter_700Bold,
     fontSize: 14,
+  },
+  TitleSmallWhite: {
+    ...Inter_700Bold,
+    fontSize: 14,
+    color: colorsTheme.white
   },
   ButtonBig: {
     ...Inter_500Medium,
@@ -45,4 +55,7 @@ export const fontsTheme = {
     ...Inter_400Regular,
     fontSize: 12,
   },
+  whiteColor: {
+    color: colorsTheme.white,
+  }
 };

--- a/client/styles/fontsTheme.js
+++ b/client/styles/fontsTheme.js
@@ -32,6 +32,11 @@ export const fontsTheme = {
     fontSize: 14,
     color: colorsTheme.white
   },
+  ButtonSmallGreen: {
+    ...Inter_500Medium,
+    fontSize: 14,
+    color: colorsTheme.darkGreen
+  },
   TextBig: {
     ...Inter_400Regular,
     fontSize: 14,


### PR DESCRIPTION
# Create Balance Display Component  

## Description  
This Pull Request introduces the **Balance Display component**, which presents the user's **current balance, expenses, and incomes**. The component is purely for **display purposes**, ensuring accurate financial data visualization without interactivity.  

## Acceptance Criteria  
- The Balance Display component **renders correctly** with valid financial data.  
- Displays **"$ 0.00"** if `income` or `expense` contains invalid values.  
- The component maintains **correct formatting and styling**.  
- Unit tests ensure **reliable behavior** across different test cases.

## Usage
```
<BalanceDisplay income={12000} expense={1700}/>
```

## Preview
|Design | Result |
|----------|-----------|
|  ![image](https://github.com/user-attachments/assets/146d3812-bbd2-479f-aaf6-a56f7dafb742) |  ![image](https://github.com/user-attachments/assets/24462e4d-c454-4027-b298-166f5676d262) |

## Tests
|Screenshot of tests|
|----------------------------|
| ![Image](https://github.com/user-attachments/assets/1b97825b-3dec-4bad-884f-1222c5d6fc69) |