### PR TITLE
PR-Sprint-1/issue#9---create expense-income-category element

### DIFF
--- a/client/components/ActivityDisplay.js
+++ b/client/components/ActivityDisplay.js
@@ -1,0 +1,71 @@
+import { View } from 'react-native'
+import React from 'react'
+import { Ionicons } from "@expo/vector-icons";
+import * as Icon from "@expo/vector-icons";
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+import { activityDisplay } from '../styles/components/activity-display'
+import CustomText from './CustomText'
+import { colorsTheme } from '../styles/colorsTheme';
+
+const ActivityDisplay = ({title, date, quantity = 0, icon, screen, color}) => {
+    const formatTitle = title ? title : 'nombre no encontrado'; //Validates if there is data in the title, if not, sets a default title
+    const formatDate = date ? format(date, "dd 'de' MMMM yyyy", {locale: es}) : 'fecha no encontrada'; //takes the date and formats it
+    const iconColor = color ? color : '#c94848'; //Validates if there is data in the color, if not, sets a default color
+    const iconBackground = color ? `${color}1a` : '#c948481a'; // takes the property color and adds a default opacity to it
+    const iconName = icon.iconName ? icon.iconName : 'alert-circle-sharp'; //Validates if there is data in the icon name, if not, sets a default icon
+    const quantityColor = screen === 'income' //changes the text color depending on the screen
+        ? 'TextBigGreen'
+        : screen === 'expense'
+            ? 'TextBigRed'
+            : 'TextBigTeal'
+    const validQuantity = Number(quantity) || 0; //Validates if the quantity is a number and if not, adds 0 by default.
+    const quantityText = quantity ? `${screen === 'expense' ? '-' : ''} $ ${validQuantity.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}` : '$ 0.00'; //Validates if there is data in the quantity, if not, sets a default quantity
+
+    const renderIcon = ({ icon }) => {
+        const iconSets = {
+          AntDesign: Icon.AntDesign,
+          FontAwesome: Icon.FontAwesome,
+          MaterialIcons: Icon.MaterialIcons,
+          Ionicons: Icon.Ionicons,
+        };
+        const IconComponent = iconSets[icon.iconSet];
+        if (IconComponent) {
+          return (
+            <IconComponent 
+              name={iconName} 
+              size={30} 
+              color={iconColor} />
+          );
+        }
+      };
+
+  return (
+    <View style={[activityDisplay.container, activityDisplay.format]}>
+        <View style={activityDisplay.format}>
+            <View style={[activityDisplay.iconBackground, {backgroundColor: iconBackground}]}>
+            <View>{renderIcon({ icon })}</View>
+            </View>
+            <View style={activityDisplay.description}>
+                <CustomText text={formatTitle} type={'TextBig'}/>
+                { screen === 'category' ? null : <CustomText text={formatDate} type={'TextSmallGray'}/>}
+            </View>
+        </View>
+        <View style={activityDisplay.format}>
+            <CustomText 
+                text={quantityText} 
+                type={quantityColor}
+            />
+            <Ionicons 
+                testID="chevron-forward" 
+                name={'chevron-forward'} 
+                size={22} 
+                color={colorsTheme.dark} 
+                style={activityDisplay.iconForward}
+            />
+        </View>
+    </View>
+  )
+}
+
+export default ActivityDisplay

--- a/client/components/ActivityDisplay.js
+++ b/client/components/ActivityDisplay.js
@@ -13,7 +13,6 @@ const ActivityDisplay = ({title, date, quantity = 0, icon, screen, color}) => {
     const formatDate = date ? format(date, "dd 'de' MMMM yyyy", {locale: es}) : 'fecha no encontrada'; //takes the date and formats it
     const iconColor = color ? color : '#c94848'; //Validates if there is data in the color, if not, sets a default color
     const iconBackground = color ? `${color}1a` : '#c948481a'; // takes the property color and adds a default opacity to it
-    const iconName = icon.iconName ? icon.iconName : 'alert-circle-sharp'; //Validates if there is data in the icon name, if not, sets a default icon
     const quantityColor = screen === 'income' //changes the text color depending on the screen
         ? 'TextBigGreen'
         : screen === 'expense'
@@ -29,10 +28,12 @@ const ActivityDisplay = ({title, date, quantity = 0, icon, screen, color}) => {
           MaterialIcons: Icon.MaterialIcons,
           Ionicons: Icon.Ionicons,
         };
-        const IconComponent = iconSets[icon.iconSet];
+        const IconComponent = iconSets[icon?.iconSet || 'Ionicons'];
+        const iconName = icon?.iconName || 'alert-circle-sharp';
         if (IconComponent) {
           return (
             <IconComponent 
+              testID='default-icon'
               name={iconName} 
               size={30} 
               color={iconColor} />

--- a/client/components/__test__/ActivityDisplay.test.js
+++ b/client/components/__test__/ActivityDisplay.test.js
@@ -1,0 +1,53 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import ActivityDisplay from '../ActivityDisplay';
+import { format } from 'date-fns';
+import { es } from 'date-fns/locale';
+
+// Mock para evitar errores con Iconos
+jest.mock('@expo/vector-icons', () => ({
+    Ionicons: ({ name, size, color, testID }) => (
+        <mock-Ionicons testID={testID} name={name} size={size} color={color} />
+      ),
+}));
+
+describe('ActivityDisplay Component', () => {
+  const mockProps = {
+    title: 'Compra',
+    date: new Date(2024, 2, 15),
+    quantity: 150.75,
+    icon: { iconName: 'cart', iconSet: 'Ionicons' },
+    screen: 'expense',
+    color: '#ff5733',
+  };
+
+  test('renders correctly with given props', () => {
+    const { getByText } = render(<ActivityDisplay {...mockProps} />);
+    expect(getByText('Compra')).toBeTruthy();
+    expect(getByText(format(mockProps.date, "dd 'de' MMMM yyyy", { locale: es }))).toBeTruthy();
+    expect(getByText('- $ 150.75')).toBeTruthy();
+  });
+
+  test('renders default values when no props are provided', () => {
+    const { getByText, getByTestId } = render(<ActivityDisplay />);
+    expect(getByText('nombre no encontrado')).toBeTruthy();
+    expect(getByText('fecha no encontrada')).toBeTruthy();
+    expect(getByTestId('default-icon')).toBeTruthy();
+    expect(getByText('$ 0.00')).toBeTruthy();
+  });
+
+  test('renders correct quantity format for income screen', () => {
+    const { getByText } = render(<ActivityDisplay {...mockProps} screen='income' />);
+    expect(getByText('$ 150.75')).toBeTruthy();
+  });
+
+  test('renders correct quantity format for expense screen', () => {
+    const { getByText } = render(<ActivityDisplay {...mockProps} screen='expense' />);
+    expect(getByText('- $ 150.75')).toBeTruthy();
+  });
+
+  test('renders chevron-forward icon', () => {
+    const { getByTestId } = render(<ActivityDisplay {...mockProps} />);
+    expect(getByTestId('chevron-forward')).toBeTruthy();
+  });
+});

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -12,6 +12,7 @@
         "@expo/vector-icons": "^14.0.2",
         "@react-navigation/bottom-tabs": "^7.2.0",
         "@react-navigation/native": "^7.0.14",
+        "date-fns": "^4.1.0",
         "expo": "~52.0.37",
         "expo-blur": "~14.0.3",
         "expo-constants": "~17.0.7",
@@ -5741,6 +5742,15 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {

--- a/client/package.json
+++ b/client/package.json
@@ -11,9 +11,11 @@
     "test": "jest --watchAll",
     "lint": "expo lint"
   },
-    "jest": {
+  "jest": {
     "preset": "jest-expo",
-    "setupFiles": ["<rootDir>/jest.setup.js"],
+    "setupFiles": [
+      "<rootDir>/jest.setup.js"
+    ],
     "clearMocks": true
   },
   "dependencies": {
@@ -21,6 +23,7 @@
     "@expo/vector-icons": "^14.0.2",
     "@react-navigation/bottom-tabs": "^7.2.0",
     "@react-navigation/native": "^7.0.14",
+    "date-fns": "^4.1.0",
     "expo": "~52.0.37",
     "expo-blur": "~14.0.3",
     "expo-constants": "~17.0.7",

--- a/client/styles/colorsTheme.js
+++ b/client/styles/colorsTheme.js
@@ -7,4 +7,5 @@ export const colorsTheme = {
   black: "#2F3743",
   white: "#FDFDFD",
   lightGray: "#ECF1F6",
+  darkGray: "#7c8996",
 };

--- a/client/styles/components/activity-display.js
+++ b/client/styles/components/activity-display.js
@@ -1,0 +1,25 @@
+import { StyleSheet } from "react-native";
+import { colorsTheme } from "../colorsTheme";
+
+export const activityDisplay = StyleSheet.create({
+    container: {
+        paddingVertical: 7,
+        borderBottomWidth: 1,
+        borderBottomColor: colorsTheme.lightGray
+    },
+    format: {
+        flexDirection: 'row',
+        justifyContent: 'space-between',
+        alignItems: 'center'
+    },
+    iconBackground: {
+        padding: 13,
+        borderRadius: 50,  
+    },
+    description: {
+        marginLeft: 8,
+    },
+    iconForward: {
+        marginRight: -7,
+    }
+})

--- a/client/styles/fontsTheme.js
+++ b/client/styles/fontsTheme.js
@@ -51,9 +51,29 @@ export const fontsTheme = {
     ...Inter_400Regular,
     fontSize: 14,
   },
+  TextBigGreen: {
+    ...Inter_400Regular,
+    fontSize: 14,
+    color: colorsTheme.lightGreen
+  },
+  TextBigRed: {
+    ...Inter_400Regular,
+    fontSize: 14,
+    color: colorsTheme.red
+  },
+  TextBigTeal: {
+    ...Inter_400Regular,
+    fontSize: 14,
+    color: colorsTheme.teal
+  },
   TextSmall: {
     ...Inter_400Regular,
     fontSize: 12,
+  },
+  TextSmallGray: {
+    ...Inter_400Regular,
+    fontSize: 12,
+    color: colorsTheme.darkGray,
   },
   whiteColor: {
     color: colorsTheme.white,


### PR DESCRIPTION
# Create Activity Display Component  (for incomes, expenses and categories)

## Description  
This Pull Request introduces the **ActivityDisplay component**, which is responsible for displaying **income, expenses, and category items** within the application. The component ensures a **clear distinction** between different transaction types through **color-coded styling** while maintaining a reusable and responsive design.  

## Acceptance Criteria  
- The ActivityDisplay  **renders correctly** for incomes, expenses, and categories.  
- Amounts are **color-coded** based on their transaction type.  
- The component supports **customizable props** for amount, description, and category name.  
- Layout remains **consistent and responsive** across devices.  
- Unit tests validate the **correct behavior of the component**. 

## Usage
```
const dataExample = {
    title: '2da Quincena', 
    date: '2025-03-20T00:00:00Z', 
    icon: {
      iconName: 'attach-money', 
      iconSet: 'MaterialIcons'
    }, 
    quantity: 12000, 
    color: "#53BB53",
  }
      <ActivityDisplay {...dataExample} screen={'expense'} />
```

## Preview Design
|Income| Expense|Category|
|-----------|-------------|-------------|
| <img width="244" alt="Image" src="https://github.com/user-attachments/assets/64db8d41-92ec-4df7-8e37-5b1d932a4d2e" /> |  <img width="234" alt="Image" src="https://github.com/user-attachments/assets/518e054e-d34c-41f0-883a-ccdfdfed8a1d" /> |  <img width="242" alt="Image" src="https://github.com/user-attachments/assets/737c436a-5461-4048-b693-2879d0e6b11c" /> |

## Preview Final Result
|Default |Income| Expense|Category|
|-----------|-------------|-------------|-----------|
|  ![image](https://github.com/user-attachments/assets/bcfbfc66-0754-44fb-8a48-cfc5d9ebf229) |  ![image](https://github.com/user-attachments/assets/6187de18-f584-439d-bf3d-b79f7956744d) | ![image](https://github.com/user-attachments/assets/44885bdd-f480-4656-8b21-59c3ba7a0f37) |  ![image](https://github.com/user-attachments/assets/b29a9c81-48fe-4f15-9c16-c19a1f93dd4e) |

## Tests
|Screenshot of tests|
|----------------------------|
| ![image](https://github.com/user-attachments/assets/c51ea4ea-8c81-4e16-85c3-50fd030a6596) |