### PR TITLE
PR-Sprint-2/issue#13---create dropdown menu for add expense income or category options

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -3,6 +3,8 @@
 # dependencies
 node_modules/
 
+# coverage
+coverage/
 # Expo
 .expo/
 dist/

--- a/client/components/MenuDropdown.js
+++ b/client/components/MenuDropdown.js
@@ -1,0 +1,39 @@
+import { View, TouchableOpacity, TouchableWithoutFeedback } from 'react-native'
+import React from 'react'
+import { Ionicons, MaterialIcons, SimpleLineIcons } from '@expo/vector-icons'
+import { colorsTheme } from '../styles/colorsTheme'
+import CustomText from './CustomText'
+import { menuDropdown } from '../styles/components/menu-dropdown'
+
+const MenuDropdown = ({setIsActiveAddButton, setIsActiveMenuDropdown}) => {
+    const handleNavigation = (screen) => {
+        setIsActiveAddButton(false)
+        setIsActiveMenuDropdown(false)
+    }
+    const closeMenu = () => {
+        setIsActiveAddButton(false);
+        setIsActiveMenuDropdown(false);
+    };
+  return (
+    <TouchableWithoutFeedback onPress={closeMenu} testID="menu-overlay">
+        <View style={menuDropdown.overlay}>
+            <View style={menuDropdown.container}>
+                <TouchableOpacity  style={menuDropdown.item} onPress={() => handleNavigation('Gastos')}>
+                    <Ionicons name={'arrow-down'} size={23} color={colorsTheme.black} style={{marginRight: 10}}/>
+                    <CustomText text={'Gasto'} type={'TextBig'}/>
+                </TouchableOpacity>
+                <TouchableOpacity  style={menuDropdown.item} onPress={() => handleNavigation('Ingresos')}>
+                    <MaterialIcons name={'attach-money'} size={23} color={colorsTheme.black} style={{marginRight: 10}}/>
+                    <CustomText text={'Ingreso'} type={'TextBig'}/>
+                </TouchableOpacity>
+                <TouchableOpacity  style={menuDropdown.item} onPress={() => handleNavigation('Categorias')}>
+                    <SimpleLineIcons name={'layers'} size={19} color={colorsTheme.black} style={{marginRight: 10}}/>
+                    <CustomText text={'Categoria'} type={'TextBig'}/>
+                </TouchableOpacity>
+            </View>
+        </View>
+    </TouchableWithoutFeedback>
+  )
+}
+
+export default MenuDropdown

--- a/client/components/__test__/BalanceDisplay.test.js
+++ b/client/components/__test__/BalanceDisplay.test.js
@@ -26,6 +26,32 @@ describe('BalanceDisplay Component', () => {
     expect(getAllByText('$ 0.00')).toHaveLength(3);
   });
 
+  test('renders balance as $0.00 when income and expense are non-numeric', () => {
+    const {  getAllByText } = render(<BalanceDisplay income={'abc'} expense={'xyz'} />);
+    expect( getAllByText('$ 0.00')).toBeTruthy();
+  });
+
+  test('renders balance as 0.00 when income and expense are not provided', () => {
+    const { getAllByText } = render(<BalanceDisplay />);
+    expect(getAllByText('$ 0.00')).toBeTruthy(); // Default balance
+    expect(getAllByText('$ 0.00')).toBeTruthy(); // Default income
+    expect(getAllByText('$ 0.00')).toBeTruthy(); // Default expense
+  });
+
+test('renders balance correctly when income is undefined', () => {
+  const { getAllByText } = render(<BalanceDisplay income={undefined} expense={300} />);
+  expect(getAllByText('$ 0.00')).toBeTruthy(); // Default income
+  expect(getAllByText('$ -300.00')).toBeTruthy(); // Balance
+  expect(getAllByText('$ 300.00')).toBeTruthy(); // Expense
+});
+
+test('renders balance correctly when expense is undefined', () => {
+  const { getAllByText } = render(<BalanceDisplay income={700} expense={undefined} />);
+  expect(getAllByText('$ 700.00')).toBeTruthy(); // Income
+  expect(getAllByText('$ 700.00')).toBeTruthy(); // Balance
+  expect(getAllByText('$ 0.00')).toBeTruthy(); // Default expense
+});
+
   test('renders Ionicons correctly', () => {
     const { getAllByTestId } = render(<BalanceDisplay income={12000} expense={1700} />);
 

--- a/client/components/__test__/MenuDropdown.test.js
+++ b/client/components/__test__/MenuDropdown.test.js
@@ -1,0 +1,63 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import MenuDropdown from '../MenuDropdown';
+
+jest.mock('@expo/vector-icons', () => ({
+    Ionicons: jest.fn().mockReturnValue(null),
+    MaterialIcons: jest.fn().mockReturnValue(null),
+    SimpleLineIcons: jest.fn().mockReturnValue(null),
+  }));
+
+describe('MenuDropdown Component', () => {
+  let setIsActiveAddButtonMock, setIsActiveMenuDropdownMock;
+
+  beforeEach(() => {
+    setIsActiveAddButtonMock = jest.fn();
+    setIsActiveMenuDropdownMock = jest.fn();
+  });
+
+  test('renders menu items correctly', () => {
+    const { getByText } = render(
+      <MenuDropdown 
+        setIsActiveAddButton={setIsActiveAddButtonMock} 
+        setIsActiveMenuDropdown={setIsActiveMenuDropdownMock} 
+      />
+    );
+
+    expect(getByText('Gasto')).toBeTruthy();
+    expect(getByText('Ingreso')).toBeTruthy();
+    expect(getByText('Categoria')).toBeTruthy();
+  });
+
+  test('calls handleNavigation when an option is pressed', () => {
+    const setIsActiveAddButtonMock = jest.fn();
+    const setIsActiveMenuDropdownMock = jest.fn();
+    const { getByText } = render(
+      <MenuDropdown 
+        setIsActiveAddButton={setIsActiveAddButtonMock} 
+        setIsActiveMenuDropdown={setIsActiveMenuDropdownMock} 
+      />
+    );
+
+    fireEvent.press(getByText('Gasto'));
+    fireEvent.press(getByText('Ingreso'));
+    fireEvent.press(getByText('Categoria'));
+    expect(setIsActiveAddButtonMock).toHaveBeenCalledWith(false);
+    expect(setIsActiveMenuDropdownMock).toHaveBeenCalledWith(false);
+  });
+
+  test('closes menu when clicking outside', () => {
+    const setIsActiveAddButtonMock = jest.fn();
+    const setIsActiveMenuDropdownMock = jest.fn();
+    const { getByTestId } = render(
+      <MenuDropdown 
+        setIsActiveAddButton={setIsActiveAddButtonMock} 
+        setIsActiveMenuDropdown={setIsActiveMenuDropdownMock} 
+      />
+    );
+
+    fireEvent.press(getByTestId('menu-overlay'));
+    expect(setIsActiveAddButtonMock).toHaveBeenCalledWith(false);
+    expect(setIsActiveMenuDropdownMock).toHaveBeenCalledWith(false);
+  });
+});

--- a/client/styles/colorsTheme.js
+++ b/client/styles/colorsTheme.js
@@ -8,4 +8,5 @@ export const colorsTheme = {
   white: "#FDFDFD",
   lightGray: "#ECF1F6",
   darkGray: "#7c8996",
+  darkSmooth: "rgba(0,0,0,0.1)"
 };

--- a/client/styles/components/menu-dropdown.js
+++ b/client/styles/components/menu-dropdown.js
@@ -1,0 +1,29 @@
+import { StyleSheet } from "react-native";
+import { colorsTheme } from "../colorsTheme";
+
+export const menuDropdown = StyleSheet.create({
+  overlay: {
+    position: 'absolute',
+    top: 0,
+    left: 0,
+    right: 0,
+    bottom: 0,
+    backgroundColor: colorsTheme.darkSmooth,
+  },
+  container: {
+    position: 'absolute',
+    borderWidth: 1,
+    borderColor: colorsTheme.lightGray,
+    borderRadius: 15,
+    width: '40%',
+    right: 30,
+    bottom: 120,
+    backgroundColor: colorsTheme.white,
+  },
+  item: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "flex-start",
+    margin: 7,
+  },
+});


### PR DESCRIPTION
# Create Dropdown Menu for Add Button
## Description
This Pull Request introduces a **dropdown menu** that appears above the "Add" button when clicked on the home screen. The menu provides users with options to add an expense, income, or category, enhancing the app's usability by streamlining the addition of financial data.

## Acceptance Criteria
- The dropdown menu is displayed when clicking the "Add" button.
- The menu contains the options "Expense," "Income," and "Category."
- The menu is hidden when clicking outside of it or after selecting an option.
- The styling is consistent with the app’s UI design and ensures correct positioning above the button.
- The functionality is tested across different devices and screen sizes for usability.
- Includes unit tests to validate expected behavior.

## Usage (in `main` screen)
```
const [isActiveAddButton, setIsActiveAddButton] = useState(false);
  const [isActiveMenuDropdown, setIsActiveMenuDropdown] = useState(false);

  const showMenu = () => {
    setIsActiveAddButton(!isActiveAddButton)
    isActiveAddButton ? setIsActiveMenuDropdown(false) : setIsActiveMenuDropdown(true);
  };
  
  {isActiveMenuDropdown 
          && (<MenuDropdown 
              setIsActiveAddButton={setIsActiveAddButton}
              setIsActiveMenuDropdown={setIsActiveMenuDropdown}
            />) 
          }
```

## Preview
| Design | Final Result |
|------------|------------------|
| ![image](https://github.com/user-attachments/assets/90121511-7b06-470a-a534-b4403d6490b7) | ![image](https://github.com/user-attachments/assets/143befeb-728d-4b9f-bb96-a02107e53b45)|

## Test
| Screenshot of tests |
|---------------|
| ![image](https://github.com/user-attachments/assets/0ddd397c-6a7b-4325-a2f8-23bc15aed438)| 