### PR TITLE
PR-Sprint-3/issue#25---create income screen

### DIFF
--- a/client/app/Incomes.js
+++ b/client/app/Incomes.js
@@ -1,0 +1,217 @@
+import { View, FlatList, Animated, Easing, Pressable } from 'react-native'
+import React, { useState, useRef, useEffect } from 'react'
+import { Ionicons } from '@expo/vector-icons';
+import { isSameDay, isAfter, isBefore, subDays } from 'date-fns';
+import Header from '../components/Header'
+import CustomTitle from '../components/CustomTitle'
+import ActivityDisplay from '../components/ActivityDisplay'
+import CustomText from '../components/CustomText'
+import AddButton from '../components/AddButton'
+import { incomesData } from '../constants/incomesData'
+import { general } from '../styles/general'
+import { colorsTheme } from '../styles/colorsTheme';
+import { incomes } from '../styles/screens/incomes';
+import ModalIncome from '../components/ModalIncome';
+
+const Incomes = () => {
+    const [selectedIncome, setSelectedIncome] = useState(null);
+    const [isActiveModalIncome, setIsActiveModalIncome] = useState(false);
+    const fixedIncomes = incomesData.filter(item => item.fixed === true); //incomes fixed
+    const today = new Date();
+    const twoWeeksAgo = subDays(today, 14);
+    const [isActiveAddButton, setIsActiveAddButton] = useState(false);
+    const [expandedSections, setExpandedSections] = useState({
+        fixed: false,
+        today: false,
+        last: false
+      });
+
+      const todayIncomes = incomesData.filter((item) => //incomes of today
+        isSameDay(new Date(item.date), today)
+      );
+
+      const lastTwoWeeksIncomes = incomesData.filter((item) => { //incomes of last two weeks
+        const incomeDate = new Date(item.date);
+        return isAfter(incomeDate, twoWeeksAgo) && isBefore(incomeDate, today);
+      });
+
+      const toggleSection = (section) => {
+        setExpandedSections((prev) => ({
+          ...prev,
+          [section]: !prev[section],
+        }));
+      };
+      
+      const getIcon = (section) => 
+        expandedSections[section] ? 'chevron-up-outline' : 'chevron-down-outline';
+      
+      const showBottom = () => {
+        setIsActiveAddButton(!isActiveAddButton)
+      }
+
+      // const getDynamicHeight = () => {
+      //   if (expandedSections.fixed){
+      //     if(fixedIncomes.length === 1){
+      //         return { height: '10%', borderColor: 'blue'}
+      //     } else if(fixedIncomes.length === 2) {
+      //         return { height: '20%', borderColor: 'green'}
+      //     } else {
+      //         return { height: '30%', borderWidth: 1, borderColor: 'pink'}
+      //     }
+      //   };
+
+      //   if (expandedSections.today){
+      //     if(todayIncomes.length === 1){
+      //         return { height: '10%', borderWidth: 1, borderColor: 'blue'}
+      //     } else if(todayIncomes.length === 2) {
+      //         return { height: '20%'}
+      //     } else {
+      //         return { height: '30%', borderWidth: 1, borderColor: 'yellow'}
+      //     }
+      //   };
+
+      //   if (expandedSections.last){
+      //     if(!expandedSections.fixed && !expandedSections.today){
+      //         return { height: '80%'}
+      //     }
+      //   }
+      // }
+
+      const getFixedHeightStyle = () => {
+        if (!expandedSections.fixed) return {};
+        if (fixedIncomes.length === 1) return { height: '10%', borderColor: 'blue', borderWidth: 1 };
+        if (fixedIncomes.length === 2) return { height: '20%', borderColor: 'green', borderWidth: 1 };
+        return { maxHeight: '45%', borderColor: 'yellow', borderWidth: 1 };
+      };
+
+      const showModalIncome = (income) => {
+        setSelectedIncome(income);
+        setIsActiveModalIncome(true);
+      };
+  return (
+    <View style={general.safeArea}>
+        <Header title={'Ingresos'}/>
+        <View style={incomes.container}>
+            <View>
+                <Pressable 
+                  onPress={() => toggleSection('fixed')}
+                  style={incomes.container_title}>
+                    <CustomTitle title={'Ingresos fijos'} type={'TitleBig'}/>
+                        <Ionicons
+                            onPress={() => toggleSection('fixed')}
+                            name={getIcon('fixed')}
+                            size={27}
+                            color={colorsTheme.black}
+                            style={incomes.icon_chev}
+                            testID="down-icon"
+                        />
+                </Pressable>
+                {expandedSections.fixed && fixedIncomes.length === 0
+                    ? ( <View style={incomes.container_text}>
+                            <CustomText text={"No tienes ningún Ingreso fijo todavía"} type={'TextSmall'} numberOfLines={0}/>
+                        </View>
+                      )
+                    :   expandedSections.fixed ? 
+                      ( 
+                      <FlatList
+                            data={fixedIncomes}
+                            keyExtractor={item => item.incomeId.toString()}
+                            showsVerticalScrollIndicator={false}
+                            style={getFixedHeightStyle()}
+                            renderItem={({item}) => 
+                                <ActivityDisplay 
+                                  {... item}
+                                  onPress={()=> showModalIncome(item)} 
+                                  screen={'income'}/>
+                            }
+                        />
+                      )
+                    : null 
+                }
+                
+            </View>
+            <View>
+                <Pressable
+                  onPress={() => toggleSection('today')}
+                  style={incomes.container_title}>
+                    <CustomTitle title={'Hoy'} type={'TitleBig'}/>
+                    <Ionicons
+                        onPress={() => toggleSection('today')} 
+                        name={getIcon('today')} 
+                        size={27} 
+                        color={colorsTheme.black}
+                        style={incomes.icon_chev}
+                        testID='down-icon'
+                    />
+                </Pressable>
+                {expandedSections.today && todayIncomes.length === 0
+                    ? ( <View style={incomes.container_text}>
+                            <CustomText text={"No tienes ningún Ingreso hoy todavía"} type={'TextSmall'} numberOfLines={0}/>
+                        </View>
+                      )
+                    :   expandedSections.today ? 
+                      ( <FlatList
+                            data={todayIncomes}
+                            keyExtractor={item => item.incomeId.toString()}
+                            showsVerticalScrollIndicator={false}
+                            //style={[getDynamicHeight(), incomes.border]}
+                            renderItem={({item}) => 
+                                <ActivityDisplay 
+                                  {... item}
+                                  onPress={()=> showModalIncome(item)} 
+                                  screen={'income'}/>
+                            }
+                        />
+                      )
+                    : null 
+                }
+            </View>
+            <View>
+                <Pressable
+                  onPress={() => toggleSection('last')}
+                  style={incomes.container_title}>
+                    <CustomTitle title={'Últimas dos semanas'} type={'TitleBig'}/>
+                    <Ionicons
+                        onPress={() => toggleSection('last')} 
+                        name={getIcon('last')} 
+                        size={27} 
+                        color={colorsTheme.black}
+                        style={incomes.icon_chev}
+                        testID='down-icon'
+                    />
+                </Pressable>
+                {expandedSections.last && lastTwoWeeksIncomes.length === 0
+                    ? ( <View style={incomes.container_text}>
+                            <CustomText text={"No tienes ningún Ingreso en las últimas dos semanas"} type={'TextSmall'} numberOfLines={0}/>
+                        </View>
+                      )
+                    :   expandedSections.last ? 
+                      ( <FlatList
+                            data={lastTwoWeeksIncomes}
+                            keyExtractor={item => item.incomeId.toString()}
+                            showsVerticalScrollIndicator={false}
+                            //style={[getDynamicHeight(), incomes.border]}
+                            renderItem={({item}) => 
+                                <ActivityDisplay 
+                                  {... item} 
+                                  onPress={()=> showModalIncome(item)}
+                                  screen={'income'}/>
+                            }
+                        />
+                      )
+                    : null 
+                }
+            </View>
+        </View>
+        <AddButton onPress={showBottom} isActiveAddButton={isActiveAddButton}/>
+        {isActiveModalIncome && selectedIncome && (
+          <ModalIncome
+            {...selectedIncome}
+            setIsActiveModalIncome={setIsActiveModalIncome}
+          />
+        )}
+    </View>
+  )
+}
+
+export default Incomes

--- a/client/app/Incomes.js
+++ b/client/app/Incomes.js
@@ -80,7 +80,7 @@ const Incomes = ({ data = incomesData }) => {
   return (
     <View style={general.safeArea}>
         <Header title={'Ingresos'}/>
-        <View style={incomes.container}>
+        <View>
             <View>
                 <Pressable 
                   onPress={() => toggleSection('fixed')}

--- a/client/app/Incomes.js
+++ b/client/app/Incomes.js
@@ -85,7 +85,7 @@ const Incomes = ({ data = incomesData }) => {
                 <Pressable 
                   onPress={() => toggleSection('fixed')}
                   style={incomes.container_title}>
-                    <CustomText text={'Ingresos fijos'} type={'TitleBig'}/>
+                    <CustomText text={'Ingresos fijos'} type={'TitleMedium'}/>
                         <Ionicons
                             onPress={() => toggleSection('fixed')}
                             name={getIcon('fixed')}
@@ -124,7 +124,7 @@ const Incomes = ({ data = incomesData }) => {
                 <Pressable
                   onPress={() => toggleSection('today')}
                   style={incomes.container_title}>
-                    <CustomText text={'Hoy'} type={'TitleBig'}/>
+                    <CustomText text={'Hoy'} type={'TitleMedium'}/>
                     <Ionicons
                         onPress={() => toggleSection('today')} 
                         name={getIcon('today')} 
@@ -161,7 +161,7 @@ const Incomes = ({ data = incomesData }) => {
                 <Pressable
                   onPress={() => toggleSection('last')}
                   style={incomes.container_title}>
-                    <CustomText text={'Últimas dos semanas'} type={'TitleBig'}/>
+                    <CustomText text={'Últimas dos semanas'} type={'TitleMedium'}/>
                     <Ionicons
                         onPress={() => toggleSection('last')} 
                         name={getIcon('last')} 

--- a/client/app/Incomes.js
+++ b/client/app/Incomes.js
@@ -3,7 +3,6 @@ import React, { useState, useRef, useEffect } from 'react'
 import { Ionicons } from '@expo/vector-icons';
 import { isSameDay, isAfter, isBefore, subDays } from 'date-fns';
 import Header from '../components/Header'
-import CustomTitle from '../components/CustomTitle'
 import ActivityDisplay from '../components/ActivityDisplay'
 import CustomText from '../components/CustomText'
 import AddButton from '../components/AddButton'
@@ -12,14 +11,17 @@ import { general } from '../styles/general'
 import { colorsTheme } from '../styles/colorsTheme';
 import { incomes } from '../styles/screens/incomes';
 import ModalIncome from '../components/ModalIncome';
+import BSIncome from "../components/BSIncome";
 
 const Incomes = () => {
     const [selectedIncome, setSelectedIncome] = useState(null);
     const [isActiveModalIncome, setIsActiveModalIncome] = useState(false);
+    const [isActiveBSIncome, setIsActiveBSIncome] = useState(false);
+    const edit = false;
     const fixedIncomes = incomesData.filter(item => item.fixed === true); //incomes fixed
     const today = new Date();
     const twoWeeksAgo = subDays(today, 14);
-    const [isActiveAddButton, setIsActiveAddButton] = useState(false);
+    //const [isActiveAddButton, setIsActiveAddButton] = useState(false);
     const [expandedSections, setExpandedSections] = useState({
         fixed: false,
         today: false,
@@ -35,6 +37,15 @@ const Incomes = () => {
         return isAfter(incomeDate, twoWeeksAgo) && isBefore(incomeDate, today);
       });
 
+      const showModalIncome = (income) => {
+        setSelectedIncome(income);
+        setIsActiveModalIncome(true);
+      };
+
+      const showBottom = () => {
+        setIsActiveBSIncome(!isActiveBSIncome)
+      }
+
       const toggleSection = (section) => {
         setExpandedSections((prev) => ({
           ...prev,
@@ -44,50 +55,27 @@ const Incomes = () => {
       
       const getIcon = (section) => 
         expandedSections[section] ? 'chevron-up-outline' : 'chevron-down-outline';
-      
-      const showBottom = () => {
-        setIsActiveAddButton(!isActiveAddButton)
-      }
-
-      // const getDynamicHeight = () => {
-      //   if (expandedSections.fixed){
-      //     if(fixedIncomes.length === 1){
-      //         return { height: '10%', borderColor: 'blue'}
-      //     } else if(fixedIncomes.length === 2) {
-      //         return { height: '20%', borderColor: 'green'}
-      //     } else {
-      //         return { height: '30%', borderWidth: 1, borderColor: 'pink'}
-      //     }
-      //   };
-
-      //   if (expandedSections.today){
-      //     if(todayIncomes.length === 1){
-      //         return { height: '10%', borderWidth: 1, borderColor: 'blue'}
-      //     } else if(todayIncomes.length === 2) {
-      //         return { height: '20%'}
-      //     } else {
-      //         return { height: '30%', borderWidth: 1, borderColor: 'yellow'}
-      //     }
-      //   };
-
-      //   if (expandedSections.last){
-      //     if(!expandedSections.fixed && !expandedSections.today){
-      //         return { height: '80%'}
-      //     }
-      //   }
-      // }
 
       const getFixedHeightStyle = () => {
         if (!expandedSections.fixed) return {};
-        if (fixedIncomes.length === 1) return { height: '10%', borderColor: 'blue', borderWidth: 1 };
-        if (fixedIncomes.length === 2) return { height: '20%', borderColor: 'green', borderWidth: 1 };
-        return { maxHeight: '45%', borderColor: 'yellow', borderWidth: 1 };
+        if (fixedIncomes.length === 1) return { height: 70 };
+        if (fixedIncomes.length === 2) return { height: 135 };
+        return { height: 200 };
       };
 
-      const showModalIncome = (income) => {
-        setSelectedIncome(income);
-        setIsActiveModalIncome(true);
+      const getTodayHeightStyle = () => {
+        if (!expandedSections.today) return {};
+        if (todayIncomes.length === 1) return { height: 70 };
+        if (todayIncomes.length === 2) return { height: 135 };
+        return { height: 200 };
       };
+
+      const getLastHeightStyle = () => {
+        if (!expandedSections.last) return {};
+        if (expandedSections.today || expandedSections.fixed) return { height: 200 };
+        return { height: '80%' };
+      };
+
   return (
     <View style={general.safeArea}>
         <Header title={'Ingresos'}/>
@@ -96,7 +84,7 @@ const Incomes = () => {
                 <Pressable 
                   onPress={() => toggleSection('fixed')}
                   style={incomes.container_title}>
-                    <CustomTitle title={'Ingresos fijos'} type={'TitleBig'}/>
+                    <CustomText text={'Ingresos fijos'} type={'TitleBig'}/>
                         <Ionicons
                             onPress={() => toggleSection('fixed')}
                             name={getIcon('fixed')}
@@ -134,7 +122,7 @@ const Incomes = () => {
                 <Pressable
                   onPress={() => toggleSection('today')}
                   style={incomes.container_title}>
-                    <CustomTitle title={'Hoy'} type={'TitleBig'}/>
+                    <CustomText text={'Hoy'} type={'TitleBig'}/>
                     <Ionicons
                         onPress={() => toggleSection('today')} 
                         name={getIcon('today')} 
@@ -154,7 +142,7 @@ const Incomes = () => {
                             data={todayIncomes}
                             keyExtractor={item => item.incomeId.toString()}
                             showsVerticalScrollIndicator={false}
-                            //style={[getDynamicHeight(), incomes.border]}
+                            style={getTodayHeightStyle()}
                             renderItem={({item}) => 
                                 <ActivityDisplay 
                                   {... item}
@@ -170,7 +158,7 @@ const Incomes = () => {
                 <Pressable
                   onPress={() => toggleSection('last')}
                   style={incomes.container_title}>
-                    <CustomTitle title={'Últimas dos semanas'} type={'TitleBig'}/>
+                    <CustomText text={'Últimas dos semanas'} type={'TitleBig'}/>
                     <Ionicons
                         onPress={() => toggleSection('last')} 
                         name={getIcon('last')} 
@@ -190,7 +178,7 @@ const Incomes = () => {
                             data={lastTwoWeeksIncomes}
                             keyExtractor={item => item.incomeId.toString()}
                             showsVerticalScrollIndicator={false}
-                            //style={[getDynamicHeight(), incomes.border]}
+                            style={getLastHeightStyle()}
                             renderItem={({item}) => 
                                 <ActivityDisplay 
                                   {... item} 
@@ -203,13 +191,19 @@ const Incomes = () => {
                 }
             </View>
         </View>
-        <AddButton onPress={showBottom} isActiveAddButton={isActiveAddButton}/>
+        <AddButton onPress={showBottom}/>
         {isActiveModalIncome && selectedIncome && (
           <ModalIncome
             {...selectedIncome}
             setIsActiveModalIncome={setIsActiveModalIncome}
           />
         )}
+        <BSIncome
+        visible={isActiveBSIncome}
+        setVisible={setIsActiveBSIncome}
+        edit={edit}
+        income={selectedIncome}
+      />
     </View>
   )
 }

--- a/client/app/Incomes.js
+++ b/client/app/Incomes.js
@@ -13,12 +13,12 @@ import { incomes } from '../styles/screens/incomes';
 import ModalIncome from '../components/ModalIncome';
 import BSIncome from "../components/BSIncome";
 
-const Incomes = () => {
+const Incomes = ({ data = incomesData }) => {
     const [selectedIncome, setSelectedIncome] = useState(null);
     const [isActiveModalIncome, setIsActiveModalIncome] = useState(false);
     const [isActiveBSIncome, setIsActiveBSIncome] = useState(false);
     const [editMode, setEditMode] = useState(false);
-    const fixedIncomes = incomesData.filter(item => item.fixed === true); //incomes fixed
+    const fixedIncomes = data.filter(item => item.fixed === true); //incomes fixed
     const today = new Date();
     const twoWeeksAgo = subDays(today, 14);
     const [expandedSections, setExpandedSections] = useState({
@@ -27,11 +27,11 @@ const Incomes = () => {
         last: false
       });
 
-      const todayIncomes = incomesData.filter((item) => //incomes of today
+      const todayIncomes = data.filter((item) => //incomes of today
         isSameDay(new Date(item.date), today)
       );
 
-      const lastTwoWeeksIncomes = incomesData.filter((item) => { //incomes of last two weeks
+      const lastTwoWeeksIncomes = data.filter((item) => { //incomes of last two weeks
         const incomeDate = new Date(item.date);
         return isAfter(incomeDate, twoWeeksAgo) && isBefore(incomeDate, today);
       });
@@ -74,7 +74,7 @@ const Incomes = () => {
       const getLastHeightStyle = () => {
         if (!expandedSections.last) return {};
         if (expandedSections.today || expandedSections.fixed) return { height: 200 };
-        return { height: '80%' };
+        return { height: '86%' };
       };
 
   return (
@@ -92,7 +92,7 @@ const Incomes = () => {
                             size={27}
                             color={colorsTheme.black}
                             style={incomes.icon_chev}
-                            testID="down-icon"
+                            testID="chevron-down-outline"
                         />
                 </Pressable>
                 {expandedSections.fixed && fixedIncomes.length === 0
@@ -111,7 +111,8 @@ const Incomes = () => {
                                 <ActivityDisplay 
                                   {... item}
                                   onPress={()=> showModalIncome(item)} 
-                                  screen={'income'}/>
+                                  screen={'income'}
+                                  testID="mock-income-item"/>
                             }
                         />
                       )
@@ -130,7 +131,7 @@ const Incomes = () => {
                         size={27} 
                         color={colorsTheme.black}
                         style={incomes.icon_chev}
-                        testID='down-icon'
+                        testID='chevron-down-outline'
                     />
                 </Pressable>
                 {expandedSections.today && todayIncomes.length === 0
@@ -148,7 +149,8 @@ const Incomes = () => {
                                 <ActivityDisplay 
                                   {... item}
                                   onPress={()=> showModalIncome(item)} 
-                                  screen={'income'}/>
+                                  screen={'income'}
+                                  testID="mock-income-item"/>
                             }
                         />
                       )
@@ -166,7 +168,7 @@ const Incomes = () => {
                         size={27} 
                         color={colorsTheme.black}
                         style={incomes.icon_chev}
-                        testID='down-icon'
+                        testID='chevron-down-outline'
                     />
                 </Pressable>
                 {expandedSections.last && lastTwoWeeksIncomes.length === 0
@@ -184,7 +186,8 @@ const Incomes = () => {
                                 <ActivityDisplay 
                                   {... item} 
                                   onPress={()=> showModalIncome(item)}
-                                  screen={'income'}/>
+                                  screen={'income'}
+                                  testID="mock-income-item"/>
                             }
                         />
                       )

--- a/client/app/Incomes.js
+++ b/client/app/Incomes.js
@@ -1,5 +1,5 @@
-import { View, FlatList, Animated, Easing, Pressable } from 'react-native'
-import React, { useState, useRef, useEffect } from 'react'
+import { View, FlatList, Pressable } from 'react-native'
+import React, { useState } from 'react'
 import { Ionicons } from '@expo/vector-icons';
 import { isSameDay, isAfter, isBefore, subDays } from 'date-fns';
 import Header from '../components/Header'
@@ -17,11 +17,10 @@ const Incomes = () => {
     const [selectedIncome, setSelectedIncome] = useState(null);
     const [isActiveModalIncome, setIsActiveModalIncome] = useState(false);
     const [isActiveBSIncome, setIsActiveBSIncome] = useState(false);
-    const edit = false;
+    const [editMode, setEditMode] = useState(false);
     const fixedIncomes = incomesData.filter(item => item.fixed === true); //incomes fixed
     const today = new Date();
     const twoWeeksAgo = subDays(today, 14);
-    //const [isActiveAddButton, setIsActiveAddButton] = useState(false);
     const [expandedSections, setExpandedSections] = useState({
         fixed: false,
         today: false,
@@ -43,7 +42,9 @@ const Incomes = () => {
       };
 
       const showBottom = () => {
-        setIsActiveBSIncome(!isActiveBSIncome)
+        setSelectedIncome(null);
+        setEditMode(false);
+        setIsActiveBSIncome(true);
       }
 
       const toggleSection = (section) => {
@@ -196,12 +197,17 @@ const Incomes = () => {
           <ModalIncome
             {...selectedIncome}
             setIsActiveModalIncome={setIsActiveModalIncome}
+            onEdit={() => {
+              setEditMode(true);
+              setIsActiveModalIncome(false);
+              setIsActiveBSIncome(true);
+            }}
           />
         )}
         <BSIncome
         visible={isActiveBSIncome}
         setVisible={setIsActiveBSIncome}
-        edit={edit}
+        edit={editMode}
         income={selectedIncome}
       />
     </View>

--- a/client/app/__tests__/Incomes.test.js
+++ b/client/app/__tests__/Incomes.test.js
@@ -1,0 +1,170 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import Incomes from '../Incomes';
+
+jest.mock('@expo/vector-icons', () => ({
+    Ionicons: (props) => <div {...props} />,
+}));
+
+jest.mock('../../components/Header', () => {
+    const { Text } = require('react-native');
+    return ({title}) => (
+        <Text>{title}</Text>
+    )
+});
+jest.mock('../../components/ActivityDisplay', () => {
+    const { Text } = require('react-native');
+    return ({ name, onPress }) => (
+        <Text  onPress={onPress} testID="mock-income-item">{name}</Text>
+    )
+});
+jest.mock('../../components/CustomText', () => {
+    const { Text } = require('react-native');
+    return ({text}) => (<Text>{text}</Text>)
+});
+
+jest.mock('../../components/AddButton', () => {
+    const { Text } = require('react-native');
+    return ({ onPress }) => (
+    <Text onPress={onPress}>Add Button</Text>)
+});
+
+jest.mock('../../components/CustomButton', () => {
+    const { TouchableOpacity, Text } = require('react-native');
+    return ({ onPress, title }) => (
+        <TouchableOpacity onPress={onPress} testID={`button-${title}`}>
+        <Text>{title}</Text>
+        </TouchableOpacity>
+    );
+});
+
+jest.mock('../../components/ModalIncome', () => {
+    const { View, Text, TouchableOpacity } = require('react-native');
+  return ({ onEdit }) => (
+    <View>
+        <Text>ModalIncome</Text>
+            <TouchableOpacity onPress={onEdit}>
+            <Text>Editar</Text>
+        </TouchableOpacity>
+  </View>
+);
+});
+
+jest.mock('../../components/BSIncome', () => {
+    const { Text } = require('react-native');
+    return () => <Text>BSIncome</Text>;
+});
+
+const mockIncomesData = [
+    {
+        incomeId: 1,
+        name: 'Sueldo',
+        date: new Date().toISOString(),
+        fixed: true,
+      },
+      {
+        incomeId: 2,
+        name: 'Venta',
+        date: new Date().toISOString(),
+        fixed: false,
+      },
+  ]
+;
+
+const mockEmptyData = [];
+
+
+describe('Incomes Screen', () => {
+  it('renders header and AddButton', () => {
+    const { getByText } = render(<Incomes />);
+    expect(getByText('Ingresos')).toBeTruthy();
+    expect(getByText('Add Button')).toBeTruthy();
+  });
+
+  it('toggles fixed section and shows fixed income', () => {
+    const { getByText, getAllByTestId } = render(<Incomes data={mockIncomesData}/>);
+    fireEvent.press(getAllByTestId('chevron-down-outline')[0]); // abre 'fixed'
+    expect(getByText('Sueldo')).toBeTruthy(); // fixed income name
+  });
+
+  it('toggles today section and shows today incomes', () => {
+    const { getAllByTestId, getByText } = render(<Incomes data={mockIncomesData}/>);
+    fireEvent.press(getAllByTestId('chevron-down-outline')[1]); // abre 'today'
+    expect(getByText('Venta')).toBeTruthy(); // today income
+  });
+
+  it('toggles last two weeks section', () => {
+    const { getAllByTestId, getByText } = render(<Incomes data={mockIncomesData}/>);
+    fireEvent.press(getAllByTestId('chevron-down-outline')[2]); // abre 'last'
+    expect(getByText('Últimas dos semanas')).toBeTruthy();
+  });
+
+  it('opens ModalIncome when pressing on an income item', () => {
+    const { getAllByTestId, getByText } = render(<Incomes data={mockIncomesData}/>);
+    fireEvent.press(getAllByTestId('chevron-down-outline')[0]); 
+    fireEvent.press(getAllByTestId('mock-income-item')[0]);
+
+    expect(getByText('ModalIncome')).toBeTruthy();
+  });
+
+  it('opens BSIncome when pressing edit from ModalIncome', () => {
+    const { getAllByTestId, getByText } = render(<Incomes data={mockIncomesData} />);
+    
+    fireEvent.press(getAllByTestId('chevron-down-outline')[0]);
+    fireEvent.press(getAllByTestId('mock-income-item')[0]);
+  
+    const editar = getByText('Editar');
+    fireEvent.press(editar);
+  
+    expect(getByText('BSIncome')).toBeTruthy();
+  });
+
+  it('shows empty messages for all sections when no data', () => {
+    const { getAllByTestId, getByText } = render(<Incomes data={mockEmptyData}/>);
+    fireEvent.press(getAllByTestId('chevron-down-outline')[0]);
+    expect(getByText('No tienes ningún Ingreso fijo todavía')).toBeTruthy();
+  
+    fireEvent.press(getAllByTestId('chevron-down-outline')[1]);
+    expect(getByText('No tienes ningún Ingreso hoy todavía')).toBeTruthy();
+  
+    fireEvent.press(getAllByTestId('chevron-down-outline')[2]);
+    expect(getByText('No tienes ningún Ingreso en las últimas dos semanas')).toBeTruthy();
+  });
+
+  it('returns correct height styles based on income length', () => {
+    const singleIncome = [{
+      incomeId: 1,
+      name: 'Sueldo',
+      date: new Date().toISOString(),
+      fixed: true,
+    }];
+  
+    const { getAllByTestId, rerender } = render(<Incomes data={singleIncome} />);
+  
+    fireEvent.press(getAllByTestId('chevron-down-outline')[0]);
+    
+    rerender(<Incomes data={singleIncome} />);
+    
+    const flatLists = getAllByTestId('mock-income-item');
+    expect(flatLists.length).toBe(1);
+  });
+
+  it('returns correct height for fixed incomes section', () => {
+    const testData = [
+      { incomeId: 1, name: 'Ingreso 1', date: new Date().toISOString(), fixed: true },
+      { incomeId: 2, name: 'Ingreso 2', date: new Date().toISOString(), fixed: true },
+      { incomeId: 3, name: 'Ingreso 3', date: new Date().toISOString(), fixed: true }
+    ];
+    const { getAllByTestId } = render(<Incomes data={testData} />);
+    fireEvent.press(getAllByTestId('chevron-down-outline')[0]); // Expand 'fixed'
+  });
+
+  it('opens BSIncome when AddButton is pressed', () => {
+    const { getByText } = render(<Incomes />);
+    
+    const addButton = getByText('Add Button');
+    fireEvent.press(addButton);
+    
+    expect(getByText('BSIncome')).toBeTruthy();
+  });
+});

--- a/client/components/ActivityDisplay.js
+++ b/client/components/ActivityDisplay.js
@@ -8,16 +8,16 @@ import CustomText from './CustomText'
 import { colorsTheme } from '../styles/colorsTheme';
 import CategoryIcon from './CategoryIcon';
 
-const ActivityDisplay = ({name, date, quantity = 0, onPress, category, screen}) => {
+const ActivityDisplay = ({name, date, quantity = 0, onPress, category = {}, screen}) => {
     const formatName = name ? name : 'nombre no encontrado'; //Validates if there is data in the title, if not, sets a default title
     const formatDate = date ? format(date, "dd 'de' MMMM yyyy", {locale: es}) : 'fecha no encontrada'; //takes the date and formats it
-    const icon = screen === 'income' ?  {"iconName": "attach-money","iconSet": "MaterialIcons"} : category.icon;
-    const color = screen === 'income' ? colorsTheme.lightGreen : category.color;
+    const icon = screen === 'income' ?  {"iconName": "attach-money","iconSet": "MaterialIcons"} : category?.icon;
+    const color = screen === 'income' ? activityDisplay.green.color : category.color;
     const quantityColor = screen === 'income' //changes the text color depending on the screen
-        ? colorsTheme.lightGreen
+        ? activityDisplay.green.color
         : screen === 'expense'
-            ? colorsTheme.red
-            : colorsTheme.teal
+            ? activityDisplay.red.color
+            : activityDisplay.teal.color
     const validQuantity = Number(quantity) || 0; //Validates if the quantity is a number and if not, adds 0 by default.
     const quantityText = quantity 
         ? `${screen === 'expense' ? '-' : ''} $ ${validQuantity.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}` 
@@ -30,7 +30,7 @@ const ActivityDisplay = ({name, date, quantity = 0, onPress, category, screen}) 
             <CategoryIcon icon={icon} type={"small"} color={color}/>
             <View style={activityDisplay.description}>
                 <CustomText text={formatName} type={'TextBig'}/>
-                { screen === 'category' ? null : <CustomText text={formatDate} type={'TextSmall'} color={activityDisplay.darkGray}/>}
+                { screen === 'category' ? null : <CustomText text={formatDate} type={'TextSmall'} color={activityDisplay.darkGray.color}/>}
             </View>
         </View>
         <View style={activityDisplay.format}>

--- a/client/components/ActivityDisplay.js
+++ b/client/components/ActivityDisplay.js
@@ -1,4 +1,4 @@
-import { View } from 'react-native'
+import { TouchableOpacity, View } from 'react-native'
 import React from 'react'
 import { Ionicons } from "@expo/vector-icons";
 import { format } from 'date-fns';
@@ -8,22 +8,26 @@ import CustomText from './CustomText'
 import { colorsTheme } from '../styles/colorsTheme';
 import CategoryIcon from './CategoryIcon';
 
-const ActivityDisplay = ({name, date, quantity = 0, category, screen}) => {
+const ActivityDisplay = ({name, date, quantity = 0, onPress, category, screen}) => {
     const formatName = name ? name : 'nombre no encontrado'; //Validates if there is data in the title, if not, sets a default title
     const formatDate = date ? format(date, "dd 'de' MMMM yyyy", {locale: es}) : 'fecha no encontrada'; //takes the date and formats it
+    const icon = screen === 'income' ?  {"iconName": "attach-money","iconSet": "MaterialIcons"} : category.icon;
+    const color = screen === 'income' ? colorsTheme.lightGreen : category.color;
     const quantityColor = screen === 'income' //changes the text color depending on the screen
         ? activityDisplay.green
         : screen === 'expense'
             ? activityDisplay.red
             : activityDisplay.teal
     const validQuantity = Number(quantity) || 0; //Validates if the quantity is a number and if not, adds 0 by default.
-    const quantityText = quantity ? `${screen === 'expense' ? '-' : ''} $ ${validQuantity.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}` : '$ 0.00'; //Validates if there is data in the quantity, if not, sets a default quantity
-
-
+    const quantityText = quantity 
+        ? `${screen === 'expense' ? '-' : ''} $ ${validQuantity.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}` 
+        : '$ 0.00'; //Validates if there is data in the quantity, if not, sets a default quantity
   return (
-    <View style={[activityDisplay.container, activityDisplay.format]}>
+    <TouchableOpacity 
+        onPress={onPress}
+        style={[activityDisplay.container, activityDisplay.format]}>
         <View style={activityDisplay.format}>      
-            <CategoryIcon icon={category.icon} type={"small"} color={category.color}/>
+            <CategoryIcon icon={icon} type={"small"} color={color}/>
             <View style={activityDisplay.description}>
                 <CustomText text={formatName} type={'TextBig'}/>
                 { screen === 'category' ? null : <CustomText text={formatDate} type={'TextSmall'} color={activityDisplay.darkGray}/>}
@@ -43,7 +47,7 @@ const ActivityDisplay = ({name, date, quantity = 0, category, screen}) => {
                 style={activityDisplay.iconForward}
             />
         </View>
-    </View>
+    </TouchableOpacity>
   )
 }
 

--- a/client/components/ActivityDisplay.js
+++ b/client/components/ActivityDisplay.js
@@ -14,10 +14,10 @@ const ActivityDisplay = ({name, date, quantity = 0, onPress, category, screen}) 
     const icon = screen === 'income' ?  {"iconName": "attach-money","iconSet": "MaterialIcons"} : category.icon;
     const color = screen === 'income' ? colorsTheme.lightGreen : category.color;
     const quantityColor = screen === 'income' //changes the text color depending on the screen
-        ? activityDisplay.green
+        ? colorsTheme.lightGreen
         : screen === 'expense'
-            ? activityDisplay.red
-            : activityDisplay.teal
+            ? colorsTheme.red
+            : colorsTheme.teal
     const validQuantity = Number(quantity) || 0; //Validates if the quantity is a number and if not, adds 0 by default.
     const quantityText = quantity 
         ? `${screen === 'expense' ? '-' : ''} $ ${validQuantity.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}` 

--- a/client/components/BSIncome.js
+++ b/client/components/BSIncome.js
@@ -33,8 +33,15 @@ export default function BSExpense({ edit, visible, setVisible, income }) {
   useEffect(() => {
     if (edit) {
       setIncomeData(income);
+    }else{
+      setIncomeData({
+        name: "",
+        quantity: "",
+        date: new Date(),
+        fixed: false,
+      });
     }
-  }, [edit]);
+  }, [income, edit]);
 
   const ableToDrag = !dateModalVisible;
 

--- a/client/components/CustomButton.js
+++ b/client/components/CustomButton.js
@@ -1,7 +1,7 @@
 import { TouchableOpacity } from "react-native";
 import React from "react";
 import { customButton } from "../styles/components/custom-button";
-import CustomTitle from "./CustomTitle";
+import CustomText from "./CustomText";
 
 const CustomButton = ({ onPress, title, background, type }) => {
   const backgroundStyle =
@@ -15,15 +15,15 @@ const CustomButton = ({ onPress, title, background, type }) => {
 
   const textColor =
     background === "white" || background === undefined
-      ? customButton.green
-      : customButton.white;
+      ? customButton.green.color
+      : customButton.white.color;
 
   return (
     <TouchableOpacity
       onPress={onPress}
       style={[customButton.container, backgroundStyle, typeStyle]}
     >
-      <CustomTitle title={title} type={typeTitle} color={textColor} />
+      <CustomText text={title} type={typeTitle} color={textColor} />
     </TouchableOpacity>
   );
 };

--- a/client/components/CustomText.js
+++ b/client/components/CustomText.js
@@ -3,13 +3,12 @@ import React from "react";
 import { fontsTheme } from "../styles/fontsTheme";
 import { colorsTheme } from "../styles/colorsTheme";
 
-const CustomText = ({ text, type, numberOfLines = 1, color }) => {
+const CustomText = ({ text, type, numberOfLines = 1, color = colorsTheme.black }) => {
   const textStyle = type ? type : "TextBig";
-  const textColor = color ? color : colorsTheme.black;
   return (
     <View>
       <Text
-        style={[fontsTheme[textStyle], { color: textColor }]}
+        style={[fontsTheme[textStyle], {color: color} ]}
         numberOfLines={numberOfLines}
         ellipsizeMode="tail"
       >

--- a/client/components/ModalIncome.js
+++ b/client/components/ModalIncome.js
@@ -9,12 +9,13 @@ import { Ionicons } from '@expo/vector-icons';
 import { colorsTheme } from '../styles/colorsTheme';
 import CategoryIcon from './CategoryIcon';
 
-const ModalIncome = ({name, date, quantity = 0, icon, color, incomeId, setIsActiveModalIncome}) => {
+const ModalIncome = ({name, date, quantity = 0, incomeId, setIsActiveModalIncome}) => {
     const userId = 2; //temporal userId
     const formatName = name ? name : 'Nombre no encontrado'; //Validates if there is data in the title, if not, sets a default title
     const formatDate = date ? format(date, "dd 'de' MMMM yyyy", {locale: es}) : 'fecha no encontrada'; //takes the date and formats it
     const formatQuantity = quantity ? ` $ ${quantity.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}` : '$ 0.00'; //Validates if there is data in the quantity, if not, sets a default quantity
-    
+    const icon = {"iconName": "attach-money","iconSet": "MaterialIcons"};
+    const color = colorsTheme.lightGreen
 
     const handleDelete = (userId, incomeId) => {
         //agregar la logica para eliminar el gasto
@@ -66,7 +67,7 @@ const ModalIncome = ({name, date, quantity = 0, icon, color, incomeId, setIsActi
                     </View>
                     <View style={modalIncome.container_details}>
                         <ModalDetail title={'Ingreso:'} text={formatName}/>
-                        <ModalDetail title={'Cantidad:'} text={formatQuantity} color={modalIncome.green}/>
+                        <ModalDetail title={'Cantidad:'} text={formatQuantity} color={color}/>
                         <ModalDetail title={'fecha:'} text={formatDate}/>
                     </View>
                     <View style={modalIncome.container_buttons}>

--- a/client/components/ModalIncome.js
+++ b/client/components/ModalIncome.js
@@ -9,7 +9,13 @@ import { Ionicons } from '@expo/vector-icons';
 import { colorsTheme } from '../styles/colorsTheme';
 import CategoryIcon from './CategoryIcon';
 
-const ModalIncome = ({name, date, quantity = 0, incomeId, setIsActiveModalIncome}) => {
+const ModalIncome = ({
+    name, 
+    date, 
+    quantity = 0, 
+    incomeId, 
+    setIsActiveModalIncome,
+    onEdit}) => {
     const userId = 2; //temporal userId
     const formatName = name ? name : 'Nombre no encontrado'; //Validates if there is data in the title, if not, sets a default title
     const formatDate = date ? format(date, "dd 'de' MMMM yyyy", {locale: es}) : 'fecha no encontrada'; //takes the date and formats it
@@ -38,8 +44,8 @@ const ModalIncome = ({name, date, quantity = 0, incomeId, setIsActiveModalIncome
             ],
         )
     }
-    const handleEdit = (incomeId) => {
-        //agregar logica para editar el gasto
+    const handleEdit = () => {
+        onEdit()
     };
 
     const closeModal = () => {
@@ -78,7 +84,7 @@ const ModalIncome = ({name, date, quantity = 0, incomeId, setIsActiveModalIncome
                             type={'modal'} 
                             testID='button-Eliminar'/>
                         <CustomButton 
-                            onPress={() => handleEdit(incomeId)} 
+                            onPress={() => handleEdit()} 
                             title={'Editar'} 
                             background={'green'} 
                             type={'modal'} 

--- a/client/components/__tests__/ActivityDisplay.test.js
+++ b/client/components/__tests__/ActivityDisplay.test.js
@@ -13,11 +13,22 @@ jest.mock('@expo/vector-icons', () => ({
 
 describe('ActivityDisplay Component', () => {
   const mockProps = {
-    title: 'Compra',
+    name: 'Compra',
+    date: new Date(2024, 2, 15),
+    quantity: 150.75,
+    screen: 'expense',
+    category: {
+      icon: { iconName: 'cart', iconSet: 'Ionicons' },
+      color: '#ff0000',
+    }
+  };
+
+  const mockPropsCategory = {
+    name: 'Compra',
     date: new Date(2024, 2, 15),
     quantity: 150.75,
     icon: { iconName: 'cart', iconSet: 'Ionicons' },
-    screen: 'expense',
+    screen: 'category',
     color: '#ff5733',
   };
 
@@ -28,12 +39,23 @@ describe('ActivityDisplay Component', () => {
     expect(getByText('- $ 150.75')).toBeTruthy();
   });
 
+  test('renders correctly with screen "category"', () => {
+    const { queryByText } = render(<ActivityDisplay {...mockPropsCategory} />);
+    
+    expect(queryByText(/de/)).toBeNull();
+  });
+
   test('renders default values when no props are provided', () => {
     const { getByText, getByTestId } = render(<ActivityDisplay />);
     expect(getByText('nombre no encontrado')).toBeTruthy();
     expect(getByText('fecha no encontrada')).toBeTruthy();
     expect(getByTestId('default-icon')).toBeTruthy();
     expect(getByText('$ 0.00')).toBeTruthy();
+  });
+
+  test('renders with default color for unknown screen type', () => {
+    const { getByText } = render(<ActivityDisplay screen="other" name="Otro" quantity={50} />);
+    expect(getByText('$ 50.00')).toBeTruthy();
   });
 
   test('renders correct quantity format for income screen', () => {

--- a/client/components/__tests__/CustomButton.test.js
+++ b/client/components/__tests__/CustomButton.test.js
@@ -1,0 +1,62 @@
+import React from 'react';
+import { render, fireEvent } from '@testing-library/react-native';
+import CustomButton from '../CustomButton';
+
+// Mock del componente CustomText
+jest.mock('../CustomText', () => {
+  const { Text } = require('react-native');
+  return ({ text}) => (<Text>{text}</Text>);
+});
+
+describe('CustomButton', () => {
+  const mockPress = jest.fn();
+
+  it('renders with green background and big title by default', () => {
+    const { getByText } = render(
+      <CustomButton
+        title="Guardar"
+        onPress={() => {}}
+        background="green"
+      />
+    );
+
+    expect(getByText('Guardar')).toBeTruthy();
+  });
+
+  it('renders with white background and small title when type is modal', () => {
+    const { getByText } = render(
+      <CustomButton
+        title="Eliminar"
+        onPress={mockPress}
+        background="white"
+        type="modal"
+      />
+    );
+
+    expect(getByText('Eliminar')).toBeTruthy();
+  });
+
+  it('calls onPress when pressed', () => {
+    const { getByText } = render(
+      <CustomButton
+        title="Presioname"
+        onPress={mockPress}
+        background="green"
+      />
+    );
+
+    fireEvent.press(getByText('Presioname'));
+    expect(mockPress).toHaveBeenCalled();
+  });
+
+  it('renders correctly with no background or type props', () => {
+    const { getByText } = render(
+      <CustomButton
+        title="Por defecto"
+        onPress={mockPress}
+      />
+    );
+
+    expect(getByText('Por defecto')).toBeTruthy();
+  });
+});

--- a/client/components/__tests__/CustomText.test.js
+++ b/client/components/__tests__/CustomText.test.js
@@ -1,0 +1,36 @@
+import React from 'react';
+import { render } from '@testing-library/react-native';
+import CustomText from '../CustomText';
+import { colorsTheme } from '../../styles/colorsTheme';
+
+describe('CustomText', () => {
+  it('renders the provided text', () => {
+    const { getByText } = render(<CustomText text="Hola Mundo" />);
+    expect(getByText('Hola Mundo')).toBeTruthy();
+  });
+
+  it('applies the correct text style when type is provided', () => {
+    const { getByText } = render(<CustomText text="Título" type="TextSmall" />);
+    const textComponent = getByText('Título');
+    expect(textComponent.props.style[0]).toHaveProperty('fontSize'); // Asegura que aplica estilo desde fontsTheme
+  });
+
+  it('uses default style "TextBig" when no type is given', () => {
+    const { getByText } = render(<CustomText text="Sin tipo" />);
+    const textComponent = getByText('Sin tipo');
+    expect(textComponent.props.style[0]).toEqual(expect.objectContaining({ fontSize: expect.any(Number) }));
+  });
+
+  it('limits the number of lines when numberOfLines is passed', () => {
+    const { getByText } = render(<CustomText text="Texto largo" numberOfLines={2} />);
+    const textComponent = getByText('Texto largo');
+    expect(textComponent.props.numberOfLines).toBe(2);
+    expect(textComponent.props.ellipsizeMode).toBe('tail');
+  });
+
+  it('applies the correct color', () => {
+    const { getByText } = render(<CustomText text="Coloreado" color={colorsTheme.red} />);
+    const textComponent = getByText('Coloreado');
+    expect(textComponent.props.style[1]).toEqual({ color: colorsTheme.red });
+  });
+});

--- a/client/constants/income.js
+++ b/client/constants/income.js
@@ -2,11 +2,6 @@ export const income = {
     "userId": 1,
     "incomeId": 1,
     "name": "Pago de renta",
-    "date": "2011-10-10T14:48:00",
-    "color": "#3b6e40",
-    "icon": {
-        "iconName": "attach-money",
-        "iconSet": "MaterialIcons"
-        },
+    "date": "2011-10-10T14:48:00", 
     "quantity": 1000,
   }

--- a/client/constants/incomesData.js
+++ b/client/constants/incomesData.js
@@ -5,7 +5,7 @@ export const incomesData = [
       name: "Salario mensual",
       date: "2023-02-15T19:15:00",
       quantity: 2356.30,
-      fixed: true
+      fixed: false
     },
     {
       userId: 9,
@@ -13,7 +13,7 @@ export const incomesData = [
       name: "Pago freelance",
       date: "2025-03-15T13:01:00",
       quantity: 1032,
-      fixed: false
+      fixed: true
     },
     {
       userId: 9,
@@ -21,15 +21,15 @@ export const incomesData = [
       name: "Venta de artículo",
       date: "2025-03-28T12:53:00",
       quantity: 1418,
-      fixed: false
+      fixed: true
     },
     {
       userId: 1,
       incomeId: 4,
       name: "Devolución de impuestos",
-      date: "2025-03-20T20:30:00",
+      date: "2025-04-02T20:30:00",
       quantity: 1338,
-      fixed: false
+      fixed: true
     },
     {
       userId: 3,
@@ -37,7 +37,7 @@ export const incomesData = [
       name: "Regalo familiar",
       date: "2025-03-20T23:56:00",
       quantity: 2755,
-      fixed: false
+      fixed: true
     },
     {
       userId: 7,
@@ -61,7 +61,7 @@ export const incomesData = [
       name: "Ingreso por intereses",
       date: "2025-03-30T19:53:00",
       quantity: 911,
-      fixed: true
+      fixed: false
     },
     {
       userId: 2,
@@ -69,7 +69,7 @@ export const incomesData = [
       name: "Reembolso",
       date: "2025-03-30T13:44:00",
       quantity: 1387,
-      fixed: true
+      fixed: false
     },
     {
       userId: 3,
@@ -77,7 +77,7 @@ export const incomesData = [
       name: "Pago de comisión",
       date: "2025-03-15T18:41:00",
       quantity: 1143,
-      fixed: true
+      fixed: false
     },
     {
       userId: 2,

--- a/client/constants/incomesData.js
+++ b/client/constants/incomesData.js
@@ -1,0 +1,122 @@
+export const incomesData = [
+    {
+      userId: 9,
+      incomeId: 1,
+      name: "Salario mensual",
+      date: "2023-02-15T19:15:00",
+      quantity: 2356.30,
+      fixed: true
+    },
+    {
+      userId: 9,
+      incomeId: 2,
+      name: "Pago freelance",
+      date: "2025-03-15T13:01:00",
+      quantity: 1032,
+      fixed: false
+    },
+    {
+      userId: 9,
+      incomeId: 3,
+      name: "Venta de artículo",
+      date: "2025-03-28T12:53:00",
+      quantity: 1418,
+      fixed: false
+    },
+    {
+      userId: 1,
+      incomeId: 4,
+      name: "Devolución de impuestos",
+      date: "2025-03-20T20:30:00",
+      quantity: 1338,
+      fixed: false
+    },
+    {
+      userId: 3,
+      incomeId: 5,
+      name: "Regalo familiar",
+      date: "2025-03-20T23:56:00",
+      quantity: 2755,
+      fixed: false
+    },
+    {
+      userId: 7,
+      incomeId: 6,
+      name: "Alquiler recibido",
+      date: "2023-10-05T12:31:00",
+      quantity: 1612,
+      fixed: false
+    },
+    {
+      userId: 1,
+      incomeId: 7,
+      name: "Bonificación",
+      date: "2025-03-30T18:34:00",
+      quantity: 1625,
+      fixed: false
+    },
+    {
+      userId: 8,
+      incomeId: 8,
+      name: "Ingreso por intereses",
+      date: "2025-03-30T19:53:00",
+      quantity: 911,
+      fixed: true
+    },
+    {
+      userId: 2,
+      incomeId: 9,
+      name: "Reembolso",
+      date: "2025-03-30T13:44:00",
+      quantity: 1387,
+      fixed: true
+    },
+    {
+      userId: 3,
+      incomeId: 10,
+      name: "Pago de comisión",
+      date: "2025-03-15T18:41:00",
+      quantity: 1143,
+      fixed: true
+    },
+    {
+      userId: 2,
+      incomeId: 11,
+      name: "Donación recibida",
+      date: "2023-10-15T03:38:00",
+      quantity: 2612,
+      fixed: false
+    },
+    {
+      userId: 8,
+      incomeId: 12,
+      name: "Ingreso de inversión",
+      date: "2025-03-30T10:12:00",
+      quantity: 2576,
+      fixed: false
+    },
+    {
+      userId: 3,
+      incomeId: 13,
+      name: "Venta de curso",
+      date: "2023-04-14T05:47:00",
+      quantity: 2959,
+      fixed: false
+    },
+    {
+      userId: 4,
+      incomeId: 14,
+      name: "Trabajo eventual",
+      date: "2023-06-25T17:14:00",
+      quantity: 2166,
+      fixed: false
+    },
+    {
+      userId: 8,
+      incomeId: 15,
+      name: "Ingreso por consultoría",
+      date: "2023-05-28T19:54:00",
+      quantity: 590,
+      fixed: false
+    }
+  ];

--- a/client/styles/components/add-button.js
+++ b/client/styles/components/add-button.js
@@ -6,7 +6,7 @@ export const addButton = StyleSheet.create({
         position: 'absolute',
         alignItems: 'center',
         justifyContent: 'center',
-        right: 30,
+        right: 20,
         bottom: 30,
     },
     background: {

--- a/client/styles/components/modal-income.js
+++ b/client/styles/components/modal-income.js
@@ -35,7 +35,4 @@ export const modalIncome = StyleSheet.create({
     justifyContent: 'space-between',
     marginTop: '14%',
   },
-  green: {
-    color: colorsTheme.lightGreen
-  },
 });

--- a/client/styles/screens/incomes.js
+++ b/client/styles/screens/incomes.js
@@ -17,13 +17,8 @@ export const incomes = StyleSheet.create({
   container_text: {
     marginTop: 10,
     marginBottom: 20,
-
   },
   black: {
     color: colorsTheme.black
-  },
-  border: {
-        borderWidth: 1,
-    borderColor: 'red',
   }
 });

--- a/client/styles/screens/incomes.js
+++ b/client/styles/screens/incomes.js
@@ -2,9 +2,6 @@ import { StyleSheet } from "react-native";
 import { colorsTheme } from "../colorsTheme";
 
 export const incomes = StyleSheet.create({
-  container: {
-    marginTop: 100,
-  },
   container_title: {
     flexDirection: "row",
     alignItems: 'center',

--- a/client/styles/screens/incomes.js
+++ b/client/styles/screens/incomes.js
@@ -1,0 +1,31 @@
+import { StyleSheet } from "react-native";
+import { colorsTheme } from "../colorsTheme";
+
+export const incomes = StyleSheet.create({
+  container: {
+    marginTop: 100,
+  },
+  container_title: {
+    flexDirection: "row",
+    alignItems: 'center',
+    justifyContent: "flex-start",
+    borderWidth: 1,
+    borderColor: 'red',
+  },
+  icon_chev: {
+    marginTop: 5,
+    marginLeft: 10,
+  },
+  container_text: {
+    //marginTop: 10,
+   // marginBottom: 20,
+
+  },
+  black: {
+    color: colorsTheme.black
+  },
+  border: {
+        borderWidth: 1,
+    borderColor: 'red',
+  }
+});

--- a/client/styles/screens/incomes.js
+++ b/client/styles/screens/incomes.js
@@ -9,16 +9,14 @@ export const incomes = StyleSheet.create({
     flexDirection: "row",
     alignItems: 'center',
     justifyContent: "flex-start",
-    borderWidth: 1,
-    borderColor: 'red',
   },
   icon_chev: {
     marginTop: 5,
     marginLeft: 10,
   },
   container_text: {
-    //marginTop: 10,
-   // marginBottom: 20,
+    marginTop: 10,
+    marginBottom: 20,
 
   },
   black: {


### PR DESCRIPTION
## PR Issue #25  Incomes Screen Implementation

## Description
This pull request adds the new **Incomes** screen to the application. The screen organizes income data into three distinct sections for better clarity and user experience:

- **Fixed Incomes**
- **Today's Incomes**
- **Incomes from the Last Two Weeks**

## Components Integrated
Several reusable components were integrated into the screen:
- `Header`: Top navigation header
- `SideMenu`: Lateral menu for navigation
- `ModalIncome`: Modal for viewing or editing income details
- `AddButton`: Floating button to add a new income entry
- `BottomSheetIncomes`: Bottom sheet used for additional actions or information

## Preview
| Design | Result |
| ------- | ---------- | 
|![Image](https://github.com/user-attachments/assets/698d049d-a349-475d-a271-9cef0a0ed123)  |  ![image](https://github.com/user-attachments/assets/fee10288-8315-406f-9ed9-3cb7a4013f8b)|

## Screenshots for tests
| Incomes Screen | CustomButton | CustomText |
| ------- | ---------- | ----------| 
|![Image](https://github.com/user-attachments/assets/01b22860-4505-4277-b582-7595fc4ea1ab)  |  ![Image](https://github.com/user-attachments/assets/12dd5d43-5ec0-4309-9bc0-f4da78dcbb2e) | ![Image](https://github.com/user-attachments/assets/3ac81202-f8e5-4881-8b31-7a718508c5b5) |