### PR TITLE
Sprint-4/issue#31---include bottom sheet and modal on categories screen

### DIFF
--- a/client/app/Incomes.js
+++ b/client/app/Incomes.js
@@ -1,4 +1,4 @@
-import { View, FlatList, Animated, Easing, Pressable } from 'react-native'
+import { View, FlatList, Animated, Easing, Pressable, Platform } from 'react-native'
 import React, { useState, useRef, useEffect } from 'react'
 import { Ionicons } from '@expo/vector-icons';
 import { isSameDay, isAfter, isBefore, subDays } from 'date-fns';
@@ -15,6 +15,7 @@ import ModalIncome from '../components/ModalIncome';
 import BSIncome from "../components/BSIncome";
 
 const Incomes = ({ data = incomesData }) => {
+    const height = Platform.OS === "android" ? incomes.containerAnd : incomes.containerIos;
     const [selectedIncome, setSelectedIncome] = useState(null);
     const [isActiveModalIncome, setIsActiveModalIncome] = useState(false);
     const [isActiveBSIncome, setIsActiveBSIncome] = useState(false);
@@ -50,40 +51,34 @@ const Incomes = ({ data = incomesData }) => {
       }
 
       const toggleSection = (section) => {
-        setExpandedSections((prev) => ({
-          ...prev,
-          [section]: !prev[section],
-        }));
+        setExpandedSections((prev) => {
+          const isCurrentlyOpen = prev[section];
+          // Si ya está abierta, solo ciérrala (permitiendo que ninguna esté abierta)
+          if (isCurrentlyOpen) {
+            return {
+              fixed: false,
+              today: false,
+              last: false,
+            };
+          }
+          // Si está cerrada, ábrela y cierra las demás
+          return {
+            fixed: false,
+            today: false,
+            last: false,
+            [section]: true,
+          };
+        });
       };
       
       const getIcon = (section) => 
         expandedSections[section] ? 'chevron-up-outline' : 'chevron-down-outline';
 
-      const getFixedHeightStyle = () => {
-        if (!expandedSections.fixed) return {};
-        if (fixedIncomes.length === 1) return { height: 70 };
-        if (fixedIncomes.length === 2) return { height: 135 };
-        return { height: 200 };
-      };
-
-      const getTodayHeightStyle = () => {
-        if (!expandedSections.today) return {};
-        if (todayIncomes.length === 1) return { height: 70 };
-        if (todayIncomes.length === 2) return { height: 135 };
-        return { height: 200 };
-      };
-
-      const getLastHeightStyle = () => {
-        if (!expandedSections.last) return {};
-        if (expandedSections.today || expandedSections.fixed) return { height: 200 };
-        return { height: '86%' };
-      };
-
   return (
     <View style={general.safeArea}>
         <Header title={'Ingresos'}/>
-        <View>
-            <View>
+        <View style={height}>
+            <View style={{maxHeight: '90%'}}>
                 <Pressable 
                   onPress={() => toggleSection('fixed')}
                   style={incomes.container_title}>
@@ -108,7 +103,6 @@ const Incomes = ({ data = incomesData }) => {
                             data={fixedIncomes}
                             keyExtractor={item => item.incomeId.toString()}
                             showsVerticalScrollIndicator={false}
-                            style={getFixedHeightStyle()}
                             renderItem={({item}) => 
                                 <ActivityDisplay 
                                   {... item}
@@ -122,7 +116,7 @@ const Incomes = ({ data = incomesData }) => {
                 }
                 
             </View>
-            <View>
+            <View style={{maxHeight: '90%'}}>
                 <Pressable
                   onPress={() => toggleSection('today')}
                   style={incomes.container_title}>
@@ -146,7 +140,6 @@ const Incomes = ({ data = incomesData }) => {
                             data={todayIncomes}
                             keyExtractor={item => item.incomeId.toString()}
                             showsVerticalScrollIndicator={false}
-                            style={getTodayHeightStyle()}
                             renderItem={({item}) => 
                                 <ActivityDisplay 
                                   {... item}
@@ -159,7 +152,7 @@ const Incomes = ({ data = incomesData }) => {
                     : null 
                 }
             </View>
-            <View>
+            <View style={{maxHeight: '90%'}}>
                 <Pressable
                   onPress={() => toggleSection('last')}
                   style={incomes.container_title}>
@@ -183,7 +176,6 @@ const Incomes = ({ data = incomesData }) => {
                             data={lastTwoWeeksIncomes}
                             keyExtractor={item => item.incomeId.toString()}
                             showsVerticalScrollIndicator={false}
-                            style={getLastHeightStyle()}
                             renderItem={({item}) => 
                                 <ActivityDisplay 
                                   {... item} 

--- a/client/app/__tests__/categories.test.js
+++ b/client/app/__tests__/categories.test.js
@@ -1,19 +1,127 @@
-import { render } from "@testing-library/react-native";
-import CategoriesScreen from "../../app/categories"; // Adjusted import path
+import { render, fireEvent } from "@testing-library/react-native";
+import Categories from "../categories"; // Adjusted import path
 import React from "react";
 
-// Mock Header to avoid using usePathname
-jest.mock("../../components/Header", () => {
-  return function MockHeader() {
-    return null; // Simple mock that does nothing
-  };
+jest.mock('@expo/vector-icons', () => ({
+  Ionicons: (props) => <div {...props} />,
+}));
+
+jest.mock('../../components/Header', () => {
+  const { Text } = require('react-native');
+  return ({title}) => (
+      <Text>{title}</Text>
+  )
 });
 
-describe("CategoriesScreen", () => {
-  it("should render without crashing", () => {
-    render(<CategoriesScreen />);
+jest.mock('../../components/ActivityDisplay', () => {
+  const { Text } = require('react-native');
+  return ({ name, onPress }) => (
+      <Text  onPress={onPress} testID="mock-category-item">{name}</Text>
+  )
+});
 
-    // Check if CategoriesScreen renders without crashing
-    expect(true).toBeTruthy(); // Placeholder simple check
+jest.mock('../../components/AddButton', () => {
+  const { Text } = require('react-native');
+  return ({ onPress }) => (
+  <Text onPress={onPress}>Add Button</Text>)
+});
+
+jest.mock('../../components/CustomButton', () => {
+  const { TouchableOpacity, Text } = require('react-native');
+  return ({ onPress, title }) => (
+      <TouchableOpacity onPress={onPress} testID={`button-${title}`}>
+      <Text>{title}</Text>
+      </TouchableOpacity>
+  );
+});
+
+jest.mock('../../components/ModalCategory', () => {
+  const { View, Text, TouchableOpacity } = require('react-native');
+return ({ onEdit }) => (
+  <View>
+      <Text>ModalCategory</Text>
+          <TouchableOpacity onPress={onEdit}>
+          <Text>Editar</Text>
+      </TouchableOpacity>
+</View>
+);
+});
+
+jest.mock('../../components/BSCategory', () => {
+  const { Text } = require('react-native');
+  return () => <Text>BSCategory</Text>;
+});
+
+const mockCategoriesData = [
+  {
+    categoryId: 1,
+    name: "Alimentación",
+    description: "Gastos relacionados con comida y bebidas.",
+    budget: 500,
+    totalExpenses: 400,
+    color: "#FF6347",
+    icon: {
+      iconName: "fast-food-outline",
+      iconSet: "Ionicons",
+    },
+  },
+  {
+    categoryId: 2,
+    name: "Transporte",
+    description: "Gastos relacionados con transporte público, gasolina, etc.",
+    budget: 200,
+    totalExpenses: 150,
+    color: "#4682B4",
+    icon: {
+      iconName: "car-sport-outline",
+      iconSet: "Ionicons",
+    },
+  }
+]
+
+const mockEmptyData = [];
+
+
+
+describe("Categories Screen", () => {
+  it('renders header and AddButton', () => {
+    const { getByText } = render(<Categories/>);
+    expect(getByText('Categorías')).toBeTruthy();
+    expect(getByText('Add Button')).toBeTruthy();
   });
+
+  it('opens ModalCategory when pressing on a category item', () => {
+    const { getAllByTestId, getByText } = render(<Categories data={mockCategoriesData}/>); 
+    fireEvent.press(getAllByTestId('mock-category-item')[0]);
+
+    expect(getByText('ModalCategory')).toBeTruthy();
+  });
+
+  it('opens BSCategory when pressing edit from ModalCategory', () => {
+    const { getAllByTestId, getByText } = render(<Categories data={mockCategoriesData} />);
+    
+    fireEvent.press(getAllByTestId('mock-category-item')[0]);
+  
+    const editar = getByText('Editar');
+    fireEvent.press(editar);
+  
+    expect(getByText('BSCategory')).toBeTruthy();
+  });
+
+  it('shows empty message when no data', () => {
+    const { getByText } = render(<Categories data={mockEmptyData}/>);
+
+    expect(getByText('No tienes ninguna Categoría creada todavía')).toBeTruthy();
+  
+  });
+
+  it('opens BSCategory when AddButton is pressed', () => {
+    const { getByText } = render(<Categories />);
+    
+    const addButton = getByText('Add Button');
+    fireEvent.press(addButton);
+    
+    expect(getByText('BSCategory')).toBeTruthy();
+  });
+
 });

--- a/client/app/__tests__/expenses.test.js
+++ b/client/app/__tests__/expenses.test.js
@@ -82,7 +82,7 @@ const mockExpensesData = [
               icon: { iconName: "directions-bus", iconSet: "MaterialIcons" }
           },
           name: "Pasaje",
-          date: "2025-04-03T11:14:00",
+          date: "2025-04-09T11:14:00",
           quantity: 18.00,
           description: "Gastos en autobús",
           image: "",

--- a/client/app/categories.js
+++ b/client/app/categories.js
@@ -1,31 +1,77 @@
-import { View, FlatList } from "react-native";
-import React from "react";
-import { categoriesScreen } from "../styles/screens/categories";
+import { View, FlatList, Platform } from "react-native";
+import React, {useState} from "react";
+import { categories } from "../styles/screens/categories";
 import Header from "../components/Header";
 import ActivityDisplay from "../components/ActivityDisplay";
 import { categoriesData } from "../constants/categories";
 import AddButton from "../components/AddButton";
 import { general } from "../styles/general";
+import ModalCategory from "../components/ModalCategory";
+import BSCategory from "../components/BSCategory";
+import CustomText from "../components/CustomText";
 
-export default function CategoriesScreen() {
+const categoriesScreen = ({ data = categoriesData })  => {
+  const [selectedCategory, setSelectedCategory] = useState(null);
+  const [isActiveModalCategory, setIsActiveModalCategory] = useState(false);
+  const [isActiveBSCategory, setIsActiveBSCategory] = useState(false);
+  const [editMode, setEditMode] = useState(false);
+  const height = Platform.OS === "android" ? categories.containerAnd : categories.containerIos;
+
+  const showModalCategory = (category) => {
+    setSelectedCategory(category);
+    setIsActiveModalCategory(true);
+  };
+
+  const showBottom = () => {
+    setSelectedCategory(null);
+    setEditMode(false);
+    setIsActiveBSCategory(true);
+  }
   return (
     <View style={general.safeArea}>
       <Header title={"Categorías"} />
-      <View style={categoriesScreen.listContainer}>
-        <FlatList
-          data={categoriesData}
-          keyExtractor={(item, index) => index.toString()}
-          renderItem={({ item }) => (
-            <ActivityDisplay
-              name={item.name}
-              category={item}
-              screen={"category"}
-              quantity={item.budget}
-            />
-          )}
-        />
+      <View style={height}>
+      { data.length === 0
+        ?<View>
+          <CustomText text={'No tienes ninguna Categoría creada todavía'} type={'TextSmall'} numberOfLines={0} />
+         </View>
+        : <FlatList
+        data={data}
+        keyExtractor={item => item.categoryId.toString()}
+        showsVerticalScrollIndicator={false}
+        renderItem={({ item }) => (
+          <ActivityDisplay
+            name={item.name}
+            quantity={item.budget}
+            color={item.color}
+            category={item.icon}
+            onPress={()=> showModalCategory(item)}
+            screen={"category"}
+            testID="mock-category-item"
+          />
+        )}
+      /> }
       </View>
-      <AddButton />
+      <AddButton onPress={showBottom}/>
+      {isActiveModalCategory && selectedCategory && (
+          <ModalCategory
+            {...selectedCategory}
+            setIsActiveModalCategory={setIsActiveModalCategory}
+            onEdit={() => {
+              setEditMode(true);
+              setIsActiveModalCategory(false);
+              setIsActiveBSCategory(true);
+            }}
+          />
+        )}
+        <BSCategory
+        visible={isActiveBSCategory}
+        setVisible={setIsActiveBSCategory}
+        edit={editMode}
+        category={selectedCategory}
+      />
     </View>
   );
 }
+
+export default categoriesScreen

--- a/client/app/expenses.js
+++ b/client/app/expenses.js
@@ -1,4 +1,4 @@
-import { View, FlatList, Pressable } from 'react-native'
+import { View, FlatList, Pressable, Platform } from 'react-native'
 import React, { useState } from 'react'
 import { Ionicons } from '@expo/vector-icons';
 import { isSameDay, isAfter, isBefore, subDays } from 'date-fns';
@@ -14,6 +14,7 @@ import ModalExpense from '../components/ModalExpense';
 import BSExpense from "../components/BSExpense";
 
 const expenses = ({ data = expensesData }) => {
+    const height = Platform.OS === "android" ? expense.containerAnd : expense.containerIos;
     const [selectedExpense, setSelectedExpense] = useState(null);
     const [isActiveModalExpense, setIsActiveModalExpense] = useState(false);
     const [isActiveBSExpense, setIsActiveBSExpense] = useState(false);
@@ -48,40 +49,34 @@ const expenses = ({ data = expensesData }) => {
       }
 
       const toggleSection = (section) => {
-        setExpandedSections((prev) => ({
-          ...prev,
-          [section]: !prev[section],
-        }));
+        setExpandedSections((prev) => {
+          const isCurrentlyOpen = prev[section];
+          // Si ya está abierta, solo ciérrala (permitiendo que ninguna esté abierta)
+          if (isCurrentlyOpen) {
+            return {
+              fixed: false,
+              today: false,
+              last: false,
+            };
+          }
+          // Si está cerrada, ábrela y cierra las demás
+          return {
+            fixed: false,
+            today: false,
+            last: false,
+            [section]: true,
+          };
+        });
       };
       
       const getIcon = (section) => 
         expandedSections[section] ? 'chevron-up-outline' : 'chevron-down-outline';
 
-      const getFixedHeightStyle = () => {
-        if (!expandedSections.fixed) return {};
-        if (fixedExpenses.length === 1) return { height: 70 };
-        if (fixedExpenses.length === 2) return { height: 135 };
-        return { height: 200 };
-      };
-
-      const getTodayHeightStyle = () => {
-        if (!expandedSections.today) return {};
-        if (todayExpenses.length === 1) return { height: 70 };
-        if (todayExpenses.length === 2) return { height: 135 };
-        return { height: 200 };
-      };
-
-      const getLastHeightStyle = () => {
-        if (!expandedSections.last) return {};
-        if (expandedSections.today || expandedSections.fixed) return { height: 200 };
-        return { height: '86%' };
-      };
-
   return (
     <View style={general.safeArea}>
         <Header title={'Gastos'}/>
-        <View>
-            <View>
+        <View style={height}>
+            <View style={{maxHeight: '90%'}}>
                 <Pressable 
                   onPress={() => toggleSection('fixed')}
                   style={expense.container_title}>
@@ -106,7 +101,6 @@ const expenses = ({ data = expensesData }) => {
                             data={fixedExpenses}
                             keyExtractor={item => item.expenseId.toString()}
                             showsVerticalScrollIndicator={false}
-                            style={getFixedHeightStyle()}
                             renderItem={({item}) => 
                                 <ActivityDisplay 
                                   {... item}
@@ -120,7 +114,7 @@ const expenses = ({ data = expensesData }) => {
                 }
                 
             </View>
-            <View>
+            <View style={{maxHeight: '90%'}}>
                 <Pressable
                   onPress={() => toggleSection('today')}
                   style={expense.container_title}>
@@ -144,7 +138,6 @@ const expenses = ({ data = expensesData }) => {
                             data={todayExpenses}
                             keyExtractor={item => item.expenseId.toString()}
                             showsVerticalScrollIndicator={false}
-                            style={getTodayHeightStyle()}
                             renderItem={({item}) => 
                                 <ActivityDisplay 
                                   {... item}
@@ -157,7 +150,7 @@ const expenses = ({ data = expensesData }) => {
                     : null 
                 }
             </View>
-            <View>
+            <View style={{maxHeight: '90%'}}>
                 <Pressable
                   onPress={() => toggleSection('last')}
                   style={expense.container_title}>
@@ -181,7 +174,6 @@ const expenses = ({ data = expensesData }) => {
                             data={lastTwoWeeksExpenses}
                             keyExtractor={item => item.expenseId.toString()}
                             showsVerticalScrollIndicator={false}
-                            style={getLastHeightStyle()}
                             renderItem={({item}) => 
                                 <ActivityDisplay 
                                   {... item} 

--- a/client/components/ActivityDisplay.js
+++ b/client/components/ActivityDisplay.js
@@ -8,17 +8,37 @@ import CustomText from './CustomText'
 import { colorsTheme } from '../styles/colorsTheme';
 import CategoryIcon from './CategoryIcon';
 
-const ActivityDisplay = ({name, date, quantity = 0, onPress, category = {}, screen}) => {
+const ActivityDisplay = ({
+    name, 
+    date, 
+    quantity = 0,
+    color, 
+    onPress, 
+    category = {}, 
+    screen}) => {
     const formatName = name ? name : 'nombre no encontrado'; //Validates if there is data in the title, if not, sets a default title
     const formatDate = date ? format(date, "dd 'de' MMMM yyyy", {locale: es}) : 'fecha no encontrada'; //takes the date and formats it
-    const icon = screen === 'income' ?  {"iconName": "attach-money","iconSet": "MaterialIcons"} : category?.icon;
-    const color = screen === 'income' ? activityDisplay.green.color : category.color;
+    
+    const icon = screen === 'income' 
+        ?  {"iconName": "attach-money","iconSet": "MaterialIcons"} 
+        : screen === 'category'
+            ? category
+            : category?.icon;
+    
+    const colorIcon = screen === 'income' 
+        ? activityDisplay.green.color 
+        : screen === 'category'
+            ? color
+            : category.color;
+    
     const quantityColor = screen === 'income' //changes the text color depending on the screen
         ? activityDisplay.green.color
         : screen === 'expense'
             ? activityDisplay.red.color
             : activityDisplay.teal.color
-    const validQuantity = Number(quantity) || 0; //Validates if the quantity is a number and if not, adds 0 by default.
+    
+            const validQuantity = Number(quantity) || 0; //Validates if the quantity is a number and if not, adds 0 by default.
+    
     const quantityText = quantity 
         ? `${screen === 'expense' ? '-' : ''} $ ${validQuantity.toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 })}` 
         : '$ 0.00'; //Validates if there is data in the quantity, if not, sets a default quantity
@@ -27,7 +47,7 @@ const ActivityDisplay = ({name, date, quantity = 0, onPress, category = {}, scre
         onPress={onPress}
         style={[activityDisplay.container, activityDisplay.format]}>
         <View style={activityDisplay.format}>      
-            <CategoryIcon icon={icon} type={"small"} color={color}/>
+            <CategoryIcon icon={icon} type={"small"} color={colorIcon}/>
             <View style={activityDisplay.description}>
                 <CustomText text={formatName} type={'TextBig'}/>
                 { screen === 'category' ? null : <CustomText text={formatDate} type={'TextSmall'} color={activityDisplay.darkGray.color}/>}

--- a/client/components/BSCategory.js
+++ b/client/components/BSCategory.js
@@ -35,8 +35,15 @@ export default function BSCategory({ visible, setVisible, edit, category }) {
   useEffect(() => {
     if (edit) {
       setCategoryData(category);
+    }else{
+      setCategoryData({
+        name: "",
+        budget: "",
+        color: null,
+        icon: null,
+      })
     }
-  }, [edit]);
+  }, [edit, category]);
 
   const ableToDrag = !colorModalVisible && !iconModalVisible;
 

--- a/client/components/ModalCategory.js
+++ b/client/components/ModalCategory.js
@@ -14,6 +14,7 @@ const ModalCategory = ({
   icon,
   color,
   categoryId,
+  onEdit,
   setIsActiveModalCategory,
 }) => {
   const userId = 2; //temporal userId
@@ -53,7 +54,7 @@ const ModalCategory = ({
     );
   };
   const handleEdit = (categoryId) => {
-    //agregar logica para editar el gasto
+    onEdit()
   };
 
   const closeModal = () => {
@@ -84,12 +85,12 @@ const ModalCategory = ({
                 <ModalDetail
                   title={"Presupuesto:"}
                   text={formatBudget}
-                  color={modalCategory.teal}
+                  color={modalCategory.teal.color}
                 />
                 <ModalDetail
                   title={"Gastos totales:"}
                   text={formatTotalExpenses}
-                  color={modalCategory.red}
+                  color={modalCategory.red.color}
                 />
               </View>
               <View style={modalCategory.container_buttons}>

--- a/client/components/ModalDetail.js
+++ b/client/components/ModalDetail.js
@@ -1,13 +1,12 @@
 import { View } from 'react-native'
 import React from 'react'
-import CustomTitle from './CustomTitle'
 import CustomText from './CustomText'
 import { modalDetail } from '../styles/components/modal-detail'
 
 const ModalDetail = ({title, text, color}) => {
   return (
       <View style={modalDetail.container}>
-        <CustomTitle title={title} type={'TitleSmall'} />
+        <CustomText text={title} type={'TitleSmall'} />
         <CustomText text={text} type={'TextBig'} color={color}/>
       </View>
   )

--- a/client/components/ModalExpense.js
+++ b/client/components/ModalExpense.js
@@ -71,38 +71,6 @@ const ModalExpense = ({
     const closeModal = () => {
         setIsActiveModalExpense(false);
     };
-  return (
-    <Modal>
-        <TouchableWithoutFeedback onPress={closeModal} testID="modal-overlay">
-            <View style={modalExpense.overlay}>
-            <TouchableWithoutFeedback>
-                <View style={[modalExpense.container, heightModal]}>
-                    <View style={modalExpense.container_closeIcon}>
-                        <Ionicons
-                            onPress={closeModal} 
-                            name={'close'} 
-                            size={27} 
-                            color={colorsTheme.black}
-                            testID='close-icon'
-                            />
-                    </View>
-                    <View>
-                        <View style={modalExpense.container_icon}>
-                            <CategoryIcon icon={category.icon} type={"big"} color={category.color}/>
-                            <Text style={[fontsTheme.TitleSmall, {color: category.color}]}>{formatNameCategory}</Text>
-                        </View>
-                    </View>
-                    <View style={modalExpense.container_details}>
-                        <ModalDetail title={'Gasto:'} text={formatNameExpense}/>
-                        <ModalDetail title={'Cantidad:'} text={quantityText} color={modalExpense.red.color}/>
-                        <ModalDetail title={'Fecha:'} text={formatDate}/>
-                    </View>
-                    <View style={[modalExpense.container_inputAndImage, heightInputs]}>
-                        <CustomInput 
-                            label={'Descripcion:'}
-                            type={'paragraph'}
-                            value={description}
-                            />
 
   return (
     <Modal transparent={true}>
@@ -141,7 +109,7 @@ const ModalExpense = ({
                 <ModalDetail
                   title={"Cantidad:"}
                   text={quantityText}
-                  color={modalExpense.red}
+                  color={modalExpense.red.color}
                 />
                 <ModalDetail title={"Fecha:"} text={formatDate} />
               </View>
@@ -183,3 +151,36 @@ const ModalExpense = ({
 };
 
 export default ModalExpense;
+
+/*  return (
+    <Modal>
+        <TouchableWithoutFeedback onPress={closeModal} testID="modal-overlay">
+            <View style={modalExpense.overlay}>
+            <TouchableWithoutFeedback>
+                <View style={[modalExpense.container, heightModal]}>
+                    <View style={modalExpense.container_closeIcon}>
+                        <Ionicons
+                            onPress={closeModal} 
+                            name={'close'} 
+                            size={27} 
+                            color={colorsTheme.black}
+                            testID='close-icon'
+                            />
+                    </View>
+                    <View>
+                        <View style={modalExpense.container_icon}>
+                            <CategoryIcon icon={category.icon} type={"big"} color={category.color}/>
+                            <Text style={[fontsTheme.TitleSmall, {color: category.color}]}>{formatNameCategory}</Text>
+                        </View>
+                    </View>
+                    <View style={modalExpense.container_details}>
+                        <ModalDetail title={'Gasto:'} text={formatNameExpense}/>
+                        <ModalDetail title={'Cantidad:'} text={quantityText} color={modalExpense.red.color}/>
+                        <ModalDetail title={'Fecha:'} text={formatDate}/>
+                    </View>
+                    <View style={[modalExpense.container_inputAndImage, heightInputs]}>
+                        <CustomInput 
+                            label={'Descripcion:'}
+                            type={'paragraph'}
+                            value={description}
+                            />*/

--- a/client/components/ModalExpense.js
+++ b/client/components/ModalExpense.js
@@ -79,9 +79,7 @@ const ModalExpense = ({
           <TouchableWithoutFeedback>
             <View style={[modalExpense.container, heightModal]}>
               <View
-                style={modalExpense.container_closeIcon}
-                testID="close-icon"
-              >
+                style={modalExpense.container_closeIcon}>
                 <Ionicons
                   onPress={closeModal}
                   name={"close"}

--- a/client/components/ModalIncome.js
+++ b/client/components/ModalIncome.js
@@ -52,10 +52,10 @@ const ModalIncome = ({
         setIsActiveModalIncome(false);
     };
     return (
-        <Modal>
-        <TouchableWithoutFeedback onPress={closeModal} testID="modal-overlay">
-            <View style={modalIncome.overlay}>
-            <TouchableWithoutFeedback>
+    <Modal>
+      <TouchableWithoutFeedback onPress={closeModal} testID="modal-overlay">
+        <View style={modalIncome.overlay}>
+          <TouchableWithoutFeedback>
                 <View style={modalIncome.container}>
                     <View style={modalIncome.container_closeIcon}>
                         <Ionicons
@@ -64,7 +64,7 @@ const ModalIncome = ({
                             size={27} 
                             color={colorsTheme.black}
                             testID='close-icon'
-                            />
+                        />
                     </View>
                     <View>
                         <View style={modalIncome.container_icon}>
@@ -90,34 +90,7 @@ const ModalIncome = ({
                             type={'modal'} 
                             testID='button-Editar'/>
                     </View>
-                </View>
-              </View>
-              <View style={modalIncome.container_details}>
-                <ModalDetail title={"Ingreso:"} text={formatName} />
-                <ModalDetail
-                  title={"Cantidad:"}
-                  text={formatQuantity}
-                  color={color}
-                />
-                <ModalDetail title={"fecha:"} text={formatDate} />
-              </View>
-              <View style={modalIncome.container_buttons}>
-                <CustomButton
-                  onPress={() => handleDelete(userId, incomeId)}
-                  title={"Eliminar"}
-                  background={"white"}
-                  type={"modal"}
-                  testID="button-Eliminar"
-                />
-                <CustomButton
-                  onPress={() => handleEdit(incomeId)}
-                  title={"Editar"}
-                  background={"green"}
-                  type={"modal"}
-                  testID="button-Editar"
-                />
-              </View>
-            </View>
+                  </View>
           </TouchableWithoutFeedback>
         </View>
       </TouchableWithoutFeedback>

--- a/client/components/__tests__/ModalCategory.test.js
+++ b/client/components/__tests__/ModalCategory.test.js
@@ -35,6 +35,7 @@ describe('ModalCategory Component', () => {
       iconName: "fast-food-outline",
       iconSet: "Ionicons",
     },
+    onEdit: jest.fn(),
     setIsActiveModalCategory: jest.fn()
   };
 

--- a/client/components/__tests__/ModalExpense.test.js
+++ b/client/components/__tests__/ModalExpense.test.js
@@ -3,12 +3,19 @@ import { Alert } from 'react-native';
 import { render, fireEvent } from '@testing-library/react-native';
 import ModalExpense from '../ModalExpense';
 
-jest.mock('@expo/vector-icons', () => ({
-    Ionicons: (props) => <div {...props} />,
+jest.mock('@expo/vector-icons', () => {
+  const { TouchableOpacity, Text } = require('react-native');
+  return {
+    Ionicons: ({ onPress, name, testID }) => (
+      <TouchableOpacity onPress={onPress} testID={testID}>
+        <Text>{name}</Text>
+      </TouchableOpacity>
+    ),
   AntDesign: jest.fn().mockReturnValue(null),
   FontAwesome: jest.fn().mockReturnValue(null),
   MaterialIcons: jest.fn().mockReturnValue(null),
-}));
+  }
+});
 
 jest.mock('../ImagePicker', () => 'ImagePickerComponent');
 jest.mock('../CustomButton', () => {
@@ -34,6 +41,7 @@ describe('ModalExpense Component', () => {
     image: 'fake-image-uri',
     userId: '1234',
     expenseId: '5678',
+    onEdit: jest.fn(),
     setIsActiveModalExpense: jest.fn(),
   };
 
@@ -86,7 +94,7 @@ describe('ModalExpense Component', () => {
   });
 
   it('calls close Modal when pressing overlay or close icon', () => {
-    const { getByTestId } = render(<ModalExpense {...mockProps} />);
+    const { getAllByTestId, getByTestId } = render(<ModalExpense {...mockProps} />);
 
     fireEvent.press(getByTestId('close-icon'));
     expect(mockProps.setIsActiveModalExpense).toHaveBeenCalledWith(false);

--- a/client/components/__tests__/ModalIncome.test.js
+++ b/client/components/__tests__/ModalIncome.test.js
@@ -35,6 +35,7 @@ describe('ModalIncome Component', () => {
         "iconSet": "MaterialIcons"
         },
     quantity: 1000,
+    onEdit: jest.fn(),
     setIsActiveModalIncome: jest.fn()
   }
 

--- a/client/styles/screens/categories.js
+++ b/client/styles/screens/categories.js
@@ -1,13 +1,11 @@
 import { StyleSheet } from "react-native";
 
-export const categoriesScreen = StyleSheet.create({
-  container: {
-    display: "flex",
-    width: "100%",
-    height: "100%",
-    paddingBottom: 200,
+export const categories = StyleSheet.create({
+  containerIos: {
+    height: '93%'
   },
-  listContainer: {
-    marginTop: 50,
-  },
+  containerAnd: {
+    height: '88%',
+    marginTop: 25,
+  }
 });

--- a/client/styles/screens/expense.js
+++ b/client/styles/screens/expense.js
@@ -2,6 +2,14 @@ import { StyleSheet } from "react-native";
 import { colorsTheme } from "../colorsTheme";
 
 export const expense = StyleSheet.create({
+  containerIos: {
+    height: '89%',
+    marginTop: 35,
+  },
+  containerAnd: {
+    height: '84%',
+    marginTop: 40,
+  },
   container_title: {
     flexDirection: "row",
     alignItems: 'center',

--- a/client/styles/screens/incomes.js
+++ b/client/styles/screens/incomes.js
@@ -2,6 +2,14 @@ import { StyleSheet } from "react-native";
 import { colorsTheme } from "../colorsTheme";
 
 export const incomes = StyleSheet.create({
+  containerIos: {
+    height: '89%',
+    marginTop: 35,
+  },
+  containerAnd: {
+    height: '84%',
+    marginTop: 40,
+  },
   container_title: {
     flexDirection: "row",
     alignItems: 'center',


### PR DESCRIPTION
# Categories Screen Update & Usability Improvements

## Description
This pull request addresses the update of the **Categories** screen by integrating interactive components for improved category management. It also includes usability enhancements and bug fixes in other parts of the app.

## Tasks Completed
- Added existing **Bottom Sheet** for category actions (e.g., show options on press).
- Integrated existing **Modal** for confirming category deletion or editing.
- Matched styles to align with the app's global theme.
- Tested all interactions: open, close, and confirm actions.

## Additional Updates
- Improved usability on the **Incomes** and **Expenses** screens.
- Updated and fixed **tests** for the Incomes and Expenses screens to address previous errors.
- Fixed data handling via **props** in the `ActivityDisplay` component.

## Preview
| Modal View | Bottom Sheet View |
|-------- |--------|
| ![image](https://github.com/user-attachments/assets/c4f7a495-64d9-4775-bb85-12efb878bc70) | ![image](https://github.com/user-attachments/assets/cba56962-33a5-4858-a553-4d89d9d04588) |

## Screenshots for tests
| Category Screen |
| ----------- |
|![Image](https://github.com/user-attachments/assets/823e066a-f429-4fdf-88c5-e28d3eff0b71) |
