### PR TITLE
fix: fix BottomSheetCategory error to close

### DIFF
--- a/client/app/categories.js
+++ b/client/app/categories.js
@@ -74,12 +74,13 @@ const categoriesScreen = ({ data = categories }) => {
           }}
         />
       )}
+      {isActiveBSCategory &&
       <BSCategory
         visible={isActiveBSCategory}
         setVisible={setIsActiveBSCategory}
         edit={editMode}
         category={selectedCategory}
-      />
+      />}
     </View>
   );
 };


### PR DESCRIPTION
## Description
This pull request fixes a bug where the **Bottom Sheet** on the **Categories** screen was not closing properly after certain actions. The bottom sheet now behaves as expected, improving user interaction and experience.

###  Changes Implemented
- Corrected the state management to properly control the bottom sheet visibility.
- Ensured that the bottom sheet closes after successfully adding or editing a category.

###  Testing
- Tested on Android and iOS devices to ensure consistent behavior.
- Validated that the bottom sheet closes correctly in all expected user interactions.

###  Outcome
The Categories screen now provides a smoother and more intuitive user experience by properly handling the opening and closing of the bottom sheet.