### PR TITLE
PR-Sprint-7/Issue#52---fix-bug-acitivty-indicator-BSExpense

### DIFF
--- a/client/components/BSExpense.js
+++ b/client/components/BSExpense.js
@@ -4,7 +4,6 @@ import {
   Keyboard,
   ScrollView,
   KeyboardAvoidingView,
-  ActivityIndicator,
 } from "react-native";
 import React, { useRef, useEffect, useState } from "react";
 import RBSheet from "react-native-raw-bottom-sheet";
@@ -201,7 +200,13 @@ export default function BSExpense({ edit, visible, setVisible, expense }) {
                   }
                 />
                 {isLoading ? (
-                  <ActivityIndicator size="medium" color={colorsTheme.black} />
+                  <View style={bsExpense.loading}>
+                    <CustomText
+                      text={"Cargando..."}
+                      type={"TitleMedium"}
+                      color={colorsTheme.darkGreen}
+                    />
+                  </View>
                 ) : (
                   <CustomButton
                     title={titleButton}

--- a/client/styles/components/bs-expense.js
+++ b/client/styles/components/bs-expense.js
@@ -4,4 +4,11 @@ export const bsExpense = StyleSheet.create({
   scrollview: {
     paddingBottom: Platform.OS === "android" ? 120 : 110,
   },
+  loading: {
+    width: "100%",
+    alignItems: "center",
+    justifyContent: "center",
+    height: 54,
+    margin: 10,
+  },
 });


### PR DESCRIPTION
## Description: 
This PR addresses a critical performance issue on Android devices where the BSExpense screen was causing infinite console errors. The root cause appears to be:
- A broken or improperly configured ActivityIndicator.
- An uncontrolled re-render loop, likely triggered by state or effect mismanagement.

## Changes made

- Identified uncontrolled re-render loop.
- Replaced the broken ActivityIndicator with Text component to ensure proper lifecycle behavior.
