### PR TITLE
PR-Sprint-9/issue#59---display recent activity incomes expenses in home scrollview

### DIFF
--- a/client/app/home.js
+++ b/client/app/home.js
@@ -23,7 +23,6 @@ import { general } from "../styles/general";
 export default function HomeScreen() {
   const [date, setDate] = useState({ month: "", year: "" });
   const [isMenuActive, setIsMenuActive] = useState(false);
-  const [editMode, setEditMode] = useState(false);
   const [activeSheet, setActiveSheet] = useState(null); // "Categoria", "Ingreso", "Gasto", "ModalIngreso", "ModalGasto"
   const [activity, setActivity] = useState(null); // "Ingreso", "Gasto"
   const [balance, setBalance] = useState({ totalIncome: 0, totalExpenses: 0 });
@@ -127,8 +126,7 @@ const mergeAndSortData = (incomes, expenses) => {
           {...activity}
           setIsActiveModalExpense={handleCloseSheet}
           onEdit={() => {
-            setActiveSheet("Gasto");
-            setEditMode(true)}
+            setActiveSheet("Gasto")}
           }
         />
       )}
@@ -137,8 +135,7 @@ const mergeAndSortData = (incomes, expenses) => {
           {...activity}
           setIsActiveModalIncome={handleCloseSheet}
           onEdit={() => {
-            setActiveSheet("Ingreso");
-            setEditMode(true)}
+            setActiveSheet("Ingreso")}
           }
         />
       )}

--- a/client/components/ModalCategory.js
+++ b/client/components/ModalCategory.js
@@ -40,9 +40,9 @@ const ModalCategory = ({
       await apiClient.post("/category/delete", body);
       setIsActiveModalCategory(false);
       onDelete?.();
-      Alert.alert("Gasto eliminado", "Tu gasto se ha eliminado correctamente");
+      Alert.alert("Categoría eliminada", "Tu gasto se ha eliminado correctamente");
     } catch (error) {
-      console.error("Error al intentar eliminar el gasto", error);
+      console.error("Error al intentar eliminar la categoría", error);
       Alert.alert("Error", "Porfavor intentalo de nuevo");
     }
   };
@@ -50,8 +50,8 @@ const ModalCategory = ({
   const handleDelete = () => {
     //agregar la logica para eliminar el gasto
     Alert.alert(
-      `Eliminar Categoria con id: ${id}`,
-      "¿Estas seguro que deseas eliminar la categoria?",
+      `Eliminar Categoría: ${name}`,
+      "¿Estas seguro que deseas eliminar la categoría?",
       [
         {
           text: "Eliminar",

--- a/client/components/ModalExpense.js
+++ b/client/components/ModalExpense.js
@@ -89,16 +89,7 @@ const ModalExpense = ({
   };
 
   const handleEdit = () => {
-    onEdit({
-      id: id,
-      name,
-      description,
-      amount,
-      date,
-      image,
-      category,
-    });
-    setIsActiveModalExpense(false);
+    onEdit();
   };
 
   const closeModal = () => {
@@ -163,7 +154,7 @@ const ModalExpense = ({
                   testID="button-Eliminar"
                 />
                 <CustomButton
-                  onPress={handleEdit}
+                  onPress={() => handleEdit()}
                   title={"Editar"}
                   background={"green"}
                   type={"modal"}

--- a/client/components/ModalIncome.js
+++ b/client/components/ModalIncome.js
@@ -32,10 +32,9 @@ const ModalIncome = ({
     : "$ 0.00"; //Validates if there is data in the amount, if not, sets a default amount
   const icon = { iconName: "attach-money", iconSet: "MaterialIcons" };
   const color = colorsTheme.lightGreen;
-
   const handleDelete = async (userId, incomeId) => {
     Alert.alert(
-      `Eliminar Ingreso`,
+      `Eliminar Ingreso: ${name}`,
       "¿Estás seguro que deseas eliminar este ingreso?",
       [
         {

--- a/client/components/RecentActivity.js
+++ b/client/components/RecentActivity.js
@@ -2,34 +2,20 @@ import {
   View,
   FlatList,
 } from "react-native";
-import React, { useMemo } from "react";
-import useExpensesAndIncomes from "../hooks/useExpenseAndIncomes";
+import React from "react";
 import CustomText from "./CustomText";
 import ActivityDisplay from "./ActivityDisplay";
 import { recentActivity } from "../styles/components/recent-activity";
 import { homeStyles } from "../styles/screens/home";
 
-//Function to combine and sort data
-const mergeAndSortData = (incomes, expenses) => {
-  return [...incomes, ...expenses]
-    .map((item, index) => ({ ...item, id: (index + 1).toString() }))
-    .sort((a, b) => new Date(b.date) - new Date(a.date))
-    .slice(0, 10);
-};
 
-export default function RecentActivity({ onPress }) {
-  const {expenses, incomes, loading} = useExpensesAndIncomes();
-  const combinedData = useMemo(
-    () => mergeAndSortData(incomes, expenses),
-    []
-  );
-
+export default function RecentActivity({ onPress, activity, loading }) {
   return (
     <View style={recentActivity.container}>
       <View style={recentActivity.header}>
         <CustomText text="Actividad Reciente" type="TitleSmall" />
       </View>
-      {loading 
+      {loading || activity.length === 0 
         ? (
           <View style={homeStyles.recentActivityContainer}>
             <CustomText 
@@ -40,7 +26,7 @@ export default function RecentActivity({ onPress }) {
         ): (
           <FlatList
           showsVerticalScrollIndicator={false}
-          data={combinedData}
+          data={activity}
           keyExtractor={(item) => item.id}
           renderItem={({ item }) => (
             <ActivityDisplay

--- a/client/components/RecentActivity.js
+++ b/client/components/RecentActivity.js
@@ -1,18 +1,15 @@
 import {
   View,
-  TouchableOpacity,
   FlatList,
-  ImageBackground,
 } from "react-native";
 import React, { useMemo } from "react";
-import { incomesData } from "../constants/incomesData";
-import { expensesData } from "../constants/expensesData";
+import useExpensesAndIncomes from "../hooks/useExpenseAndIncomes";
 import CustomText from "./CustomText";
 import ActivityDisplay from "./ActivityDisplay";
 import { recentActivity } from "../styles/components/recent-activity";
-import { colorsTheme } from "../styles/colorsTheme";
+import { homeStyles } from "../styles/screens/home";
 
-// Function to combine and sort data
+//Function to combine and sort data
 const mergeAndSortData = (incomes, expenses) => {
   return [...incomes, ...expenses]
     .map((item, index) => ({ ...item, id: (index + 1).toString() }))
@@ -21,8 +18,9 @@ const mergeAndSortData = (incomes, expenses) => {
 };
 
 export default function RecentActivity({ onPress }) {
+  const {expenses, incomes, loading} = useExpensesAndIncomes();
   const combinedData = useMemo(
-    () => mergeAndSortData(incomesData, expensesData),
+    () => mergeAndSortData(incomes, expenses),
     []
   );
 
@@ -31,18 +29,28 @@ export default function RecentActivity({ onPress }) {
       <View style={recentActivity.header}>
         <CustomText text="Actividad Reciente" type="TitleSmall" />
       </View>
-      <FlatList
-        showsVerticalScrollIndicator={false}
-        data={combinedData}
-        keyExtractor={(item) => item.id}
-        renderItem={({ item }) => (
-          <ActivityDisplay
-            {...item}
-            screen={item.category ? "expense" : "income"}
-            onPress={() => onPress(item)}
+      {loading 
+        ? (
+          <View style={homeStyles.recentActivityContainer}>
+            <CustomText 
+            text={"Cargando..."} 
+            type={"TextSmall"}
+            />
+          </View>
+        ): (
+          <FlatList
+          showsVerticalScrollIndicator={false}
+          data={combinedData}
+          keyExtractor={(item) => item.id}
+          renderItem={({ item }) => (
+            <ActivityDisplay
+              {...item}
+              screen={item.category ? "expense" : "income"}
+              onPress={() => onPress(item)}
+            />
+          )}
           />
         )}
-      />
     </View>
   );
 }

--- a/client/hooks/useExpenseAndIncomes.js
+++ b/client/hooks/useExpenseAndIncomes.js
@@ -4,18 +4,18 @@ import apiClient from "../api/apiClient";
 const useExpensesAndIncomes = () => {
     const [expenses, setExpenses] = useState([]);
     const [incomes, setIncomes] = useState([]);
-    const [loading, setLoading] = useState(true);
+    const [loadingIncomesAndExpenses, setloadingIncomesAndExpenses] = useState(true);
 
     const getExpensesAndIncomes = async () => {
         try {
             const responseExpenses = await apiClient.get("/expenses/get");
-            const responseIncomes = await apiClient.get("/incomes");
+            const responseIncomes = await apiClient.get("/incomes/user");
             setExpenses(responseExpenses);
             setIncomes(responseIncomes);
         } catch (error) {
             console.error('Error al obtener la actividad reciente', error)
         } finally {
-            setLoading(false);
+            setloadingIncomesAndExpenses(false);
         }
     }
 
@@ -24,7 +24,7 @@ const useExpensesAndIncomes = () => {
     }, [])
     
 
-  return {expenses, incomes, loading}
+  return {expenses, incomes, loadingIncomesAndExpenses, getExpensesAndIncomes}
 }
 
 export default useExpensesAndIncomes

--- a/client/hooks/useExpenseAndIncomes.js
+++ b/client/hooks/useExpenseAndIncomes.js
@@ -1,0 +1,30 @@
+import React, {useState, useEffect} from 'react'
+import apiClient from "../api/apiClient";
+
+const useExpensesAndIncomes = () => {
+    const [expenses, setExpenses] = useState([]);
+    const [incomes, setIncomes] = useState([]);
+    const [loading, setLoading] = useState(true);
+
+    const getExpensesAndIncomes = async () => {
+        try {
+            const responseExpenses = await apiClient.get("/expenses/get");
+            const responseIncomes = await apiClient.get("/incomes");
+            setExpenses(responseExpenses);
+            setIncomes(responseIncomes);
+        } catch (error) {
+            console.error('Error al obtener la actividad reciente', error)
+        } finally {
+            setLoading(false);
+        }
+    }
+
+    useEffect(() => {
+        getExpensesAndIncomes();
+    }, [])
+    
+
+  return {expenses, incomes, loading}
+}
+
+export default useExpensesAndIncomes

--- a/client/styles/screens/home.js
+++ b/client/styles/screens/home.js
@@ -1,4 +1,9 @@
 import { StyleSheet } from "react-native";
 export const homeStyles = StyleSheet.create({
   expensesScrollview: { marginHorizontal: -16, paddingVertical: 10 },
+  recentActivityContainer: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    marginTop: 50,
+  }
 });


### PR DESCRIPTION
## Display Recent Activity on Home Screen (Incomes & Expenses)

### Description
This pull request implements the display of **recent financial activity** on the **Home screen**, combining both **incomes** and **expenses** in a single scrollable section. The data is shown in descending order by date to highlight the most recent entries.

### Tasks Completed
- Fetched **incomes** and **expenses** using existing API endpoints.
- Merged both datasets and sorted them by date (most recent first).
- Displayed the combined activity in a vertical `ScrollView` on the Home screen.
- Handled **loading states** and empty list messages for a smoother UX.
- Replaced old state variables and logic with new sorted activity list.
- Ensured performance and consistency by avoiding repeated logic.

### Refactor & Optimization
- Used a **shared custom hook** to manage data fetching for incomes and expenses.
- This reduces code duplication and ensures consistency with the Incomes and Expenses screens.

### Outcome
Users now see a unified and up-to-date view of their latest financial activity directly from the Home screen, improving the overview of recent transactions and enhancing the overall experience.