### PR TITLE
PR-Sprint-9/issue#63---fix message when user has no recent activity

### DIFF
--- a/client/components/RecentActivity.js
+++ b/client/components/RecentActivity.js
@@ -15,7 +15,7 @@ export default function RecentActivity({ onPress, activity, loading }) {
       <View style={recentActivity.header}>
         <CustomText text="Actividad Reciente" type="TitleSmall" />
       </View>
-      {loading || activity.length === 0 
+      {loading
         ? (
           <View style={homeStyles.recentActivityContainer}>
             <CustomText 
@@ -23,20 +23,28 @@ export default function RecentActivity({ onPress, activity, loading }) {
             type={"TextSmall"}
             />
           </View>
-        ): (
-          <FlatList
-          showsVerticalScrollIndicator={false}
-          data={activity}
-          keyExtractor={(item) => item.id}
-          renderItem={({ item }) => (
-            <ActivityDisplay
-              {...item}
-              screen={item.category ? "expense" : "income"}
-              onPress={() => onPress(item)}
-            />
-          )}
-          />
-        )}
+        ): activity.length === 0 
+          ? (
+              <View style={homeStyles.recentActivityContainer}>
+                <CustomText 
+                text={"Aún no tienes ninguna actividad"} 
+                type={"TextSmall"}
+                />
+              </View>
+          )
+          : (<FlatList
+              showsVerticalScrollIndicator={false}
+              data={activity}
+              keyExtractor={(item) => item.id}
+              renderItem={({ item }) => (
+                <ActivityDisplay
+                  {...item}
+                  screen={item.category ? "expense" : "income"}
+                  onPress={() => onPress(item)}
+                />
+              )}
+          />) 
+        }
     </View>
   );
 }


### PR DESCRIPTION
### Description
This pull request fixes an issue on the **Home screen** where users without recent financial activity (no incomes or expenses) would see the misleading message `"Loading..."`. The screen now correctly displays a more informative message when no activity is found.

###  Changes Implemented
- Added a conditional check to detect when both incomes and expenses are empty.
- Replaced the `"Loading..."` message with:
  > `"You don't have any recent activity yet"`
- Ensured the new message only appears when data is fully loaded and empty.
- Tested behavior with empty datasets to confirm correct display.

### Outcome
Users with no recent activity now see a clear and accurate message, improving the **user experience** and avoiding confusion during initial app use.